### PR TITLE
feat: CI auto-comment on PR failure

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -56,6 +56,21 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Backend CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });
+
   typecheck:
     name: TypeScript
     runs-on: ubuntu-latest
@@ -79,6 +94,21 @@ jobs:
 
       - name: Run type check
         run: npx tsc --noEmit
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Backend CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });
 
   tests:
     name: Tests
@@ -122,3 +152,19 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Backend CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });
+


### PR DESCRIPTION
## Summary

Adds automatic failure notifications to PR when CI jobs fail.

## What

- Adds comment step to lint, typecheck, and tests jobs
- When any job fails, posts a comment on the PR with direct link to workflow logs
- Eliminates need to check Actions tab to see why CI failed
- Makes CI failures visible to all agents immediately

## Why

Prevents PRs from getting stuck when CI fails silently. The Developer can now see failures directly on the PR and act immediately, instead of checking the Actions tab. This also helps the Maestro understand what went wrong.

## How to test

1. Create a PR that breaks linting (e.g., add a syntax error in backend code)
2. CI should run and fail on lint job
3. Check the PR — should see a comment with failure notification and link to logs
4. Fix the code and push again
5. Confirm new CI run succeeds and no duplicate comments are posted