### PR TITLE
feat: TASK-008 - Repository implementations (Parent and School)

### DIFF
--- a/backend/src/data/data.module.ts
+++ b/backend/src/data/data.module.ts
@@ -1,17 +1,24 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ParentModel } from './models/parent.model';
+import { SchoolModel } from './models/school.model';
 import { ParentRepository } from './repositories/parent.repository';
+import { SchoolRepository } from './repositories/school.repository';
 import { PARENT_REPOSITORY } from '../domain/repositories/parent.repository.interface';
+import { SCHOOL_REPOSITORY } from '../domain/repositories/school.repository.interface';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ParentModel])],
+  imports: [TypeOrmModule.forFeature([ParentModel, SchoolModel])],
   providers: [
     {
       provide: PARENT_REPOSITORY,
       useClass: ParentRepository,
     },
+    {
+      provide: SCHOOL_REPOSITORY,
+      useClass: SchoolRepository,
+    },
   ],
-  exports: [PARENT_REPOSITORY],
+  exports: [PARENT_REPOSITORY, SCHOOL_REPOSITORY],
 })
 export class DataModule {}

--- a/backend/src/data/mappers/school.mapper.ts
+++ b/backend/src/data/mappers/school.mapper.ts
@@ -1,0 +1,29 @@
+import { School } from '../../domain/entities/school.entity';
+import { SchoolModel } from '../models/school.model';
+
+export class SchoolMapper {
+  static toDomain(model: SchoolModel): School {
+    return {
+      id: model.id,
+      name: model.name,
+      lat: model.lat,
+      lng: model.lng,
+      geofenceRadiusMeters: model.geofenceRadiusMeters,
+      notificationThresholdMeters: model.notificationThresholdMeters,
+      createdAt: model.createdAt,
+    };
+  }
+
+  static toPersistence(
+    entity: Omit<School, 'id' | 'createdAt'>,
+  ): Omit<SchoolModel, 'id' | 'createdAt'> {
+    return {
+      name: entity.name,
+      lat: entity.lat,
+      lng: entity.lng,
+      location: `POINT(${entity.lng} ${entity.lat})`,
+      geofenceRadiusMeters: entity.geofenceRadiusMeters,
+      notificationThresholdMeters: entity.notificationThresholdMeters,
+    };
+  }
+}

--- a/backend/src/data/repositories/parent.repository.spec.ts
+++ b/backend/src/data/repositories/parent.repository.spec.ts
@@ -1,0 +1,136 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ParentRepository } from './parent.repository';
+import { ParentModel } from '../models/parent.model';
+import { ParentMapper } from '../mappers/parent.mapper';
+import { Parent } from '../../domain/entities/parent.entity';
+
+describe('ParentRepository', () => {
+  let repository: ParentRepository;
+  let parentRepositoryMock: Repository<ParentModel>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ParentRepository,
+        {
+          provide: getRepositoryToken(ParentModel),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    repository = module.get<ParentRepository>(ParentRepository);
+    parentRepositoryMock = module.get<Repository<ParentModel>>(
+      getRepositoryToken(ParentModel),
+    );
+  });
+
+  describe('findById', () => {
+    it('should return null for non-existent ID', async () => {
+      const nonExistentId = 'non-existent-id';
+      jest.spyOn(parentRepositoryMock, 'findOne').mockResolvedValue(null);
+
+      const result = await repository.findById(nonExistentId);
+
+      expect(result).toBeNull();
+      expect(parentRepositoryMock.findOne).toHaveBeenCalledWith({
+        where: { id: nonExistentId },
+      });
+    });
+
+    it('should return entity for existing ID', async () => {
+      const existingId = 'existing-id';
+      const mockModel: ParentModel = {
+        id: existingId,
+        name: 'John Doe',
+        email: 'john@example.com',
+        phone: '+1234567890',
+        schoolId: 'school-id',
+        passwordHash: 'hashed-password',
+        createdAt: new Date(),
+      };
+
+      const expectedEntity: Parent = {
+        id: existingId,
+        name: 'John Doe',
+        email: 'john@example.com',
+        phone: '+1234567890',
+        schoolId: 'school-id',
+        createdAt: mockModel.createdAt,
+      };
+
+      jest.spyOn(parentRepositoryMock, 'findOne').mockResolvedValue(mockModel);
+      jest.spyOn(ParentMapper, 'toDomain').mockReturnValue(expectedEntity);
+
+      const result = await repository.findById(existingId);
+
+      expect(result).toEqual(expectedEntity);
+      expect(parentRepositoryMock.findOne).toHaveBeenCalledWith({
+        where: { id: existingId },
+      });
+      expect(ParentMapper.toDomain).toHaveBeenCalledWith(mockModel);
+    });
+  });
+
+  describe('create', () => {
+    it('should persist and return new entity', async () => {
+      const createData = {
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        phone: '+0987654321',
+        schoolId: 'school-id',
+        passwordHash: 'hashed-password',
+      };
+
+      const mockSavedModel: ParentModel = {
+        id: 'new-id',
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        phone: '+0987654321',
+        schoolId: 'school-id',
+        passwordHash: 'hashed-password',
+        createdAt: new Date(),
+      };
+
+      const expectedEntity: Parent = {
+        id: 'new-id',
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        phone: '+0987654321',
+        schoolId: 'school-id',
+        createdAt: mockSavedModel.createdAt,
+      };
+
+      const mockModelData = {
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        phone: '+0987654321',
+        schoolId: 'school-id',
+        passwordHash: 'hashed-password',
+      };
+
+      jest.spyOn(ParentMapper, 'toPersistence').mockReturnValue(mockModelData);
+      jest
+        .spyOn(parentRepositoryMock, 'create')
+        .mockReturnValue(mockSavedModel);
+      jest
+        .spyOn(parentRepositoryMock, 'save')
+        .mockResolvedValue(mockSavedModel);
+      jest.spyOn(ParentMapper, 'toDomain').mockReturnValue(expectedEntity);
+
+      const result = await repository.create(createData);
+
+      expect(result).toEqual(expectedEntity);
+      expect(ParentMapper.toPersistence).toHaveBeenCalledWith(createData);
+      expect(parentRepositoryMock.create).toHaveBeenCalledWith(mockModelData);
+      expect(parentRepositoryMock.save).toHaveBeenCalledWith(mockSavedModel);
+      expect(ParentMapper.toDomain).toHaveBeenCalledWith(mockSavedModel);
+    });
+  });
+});

--- a/backend/src/data/repositories/parent.repository.ts
+++ b/backend/src/data/repositories/parent.repository.ts
@@ -47,6 +47,10 @@ export class ParentRepository implements IParentRepository {
     return ParentMapper.toDomain(updatedModel);
   }
 
+  async delete(id: string): Promise<void> {
+    await this.parentRepository.delete(id);
+  }
+
   async validateCredentials(
     email: string,
     password: string,

--- a/backend/src/data/repositories/school.repository.spec.ts
+++ b/backend/src/data/repositories/school.repository.spec.ts
@@ -1,0 +1,142 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SchoolRepository } from './school.repository';
+import { SchoolModel } from '../models/school.model';
+import { SchoolMapper } from '../mappers/school.mapper';
+import { School } from '../../domain/entities/school.entity';
+
+describe('SchoolRepository', () => {
+  let repository: SchoolRepository;
+  let schoolRepositoryMock: Repository<SchoolModel>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SchoolRepository,
+        {
+          provide: getRepositoryToken(SchoolModel),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    repository = module.get<SchoolRepository>(SchoolRepository);
+    schoolRepositoryMock = module.get<Repository<SchoolModel>>(
+      getRepositoryToken(SchoolModel),
+    );
+  });
+
+  describe('findById', () => {
+    it('should return null for non-existent ID', async () => {
+      const nonExistentId = 'non-existent-id';
+      jest.spyOn(schoolRepositoryMock, 'findOne').mockResolvedValue(null);
+
+      const result = await repository.findById(nonExistentId);
+
+      expect(result).toBeNull();
+      expect(schoolRepositoryMock.findOne).toHaveBeenCalledWith({
+        where: { id: nonExistentId },
+      });
+    });
+
+    it('should return entity for existing ID', async () => {
+      const existingId = 'existing-id';
+      const mockModel: SchoolModel = {
+        id: existingId,
+        name: 'Test School',
+        lat: 40.7128,
+        lng: -74.006,
+        location: 'POINT(-74.006 40.7128)',
+        geofenceRadiusMeters: 1000,
+        notificationThresholdMeters: 500,
+        createdAt: new Date(),
+      };
+
+      const expectedEntity: School = {
+        id: existingId,
+        name: 'Test School',
+        lat: 40.7128,
+        lng: -74.006,
+        geofenceRadiusMeters: 1000,
+        notificationThresholdMeters: 500,
+        createdAt: mockModel.createdAt,
+      };
+
+      jest.spyOn(schoolRepositoryMock, 'findOne').mockResolvedValue(mockModel);
+      jest.spyOn(SchoolMapper, 'toDomain').mockReturnValue(expectedEntity);
+
+      const result = await repository.findById(existingId);
+
+      expect(result).toEqual(expectedEntity);
+      expect(schoolRepositoryMock.findOne).toHaveBeenCalledWith({
+        where: { id: existingId },
+      });
+      expect(SchoolMapper.toDomain).toHaveBeenCalledWith(mockModel);
+    });
+  });
+
+  describe('create', () => {
+    it('should persist and return new entity', async () => {
+      const createData = {
+        name: 'New School',
+        lat: 34.0522,
+        lng: -118.2437,
+        geofenceRadiusMeters: 800,
+        notificationThresholdMeters: 400,
+      };
+
+      const mockSavedModel: SchoolModel = {
+        id: 'new-id',
+        name: 'New School',
+        lat: 34.0522,
+        lng: -118.2437,
+        location: 'POINT(-118.2437 34.0522)',
+        geofenceRadiusMeters: 800,
+        notificationThresholdMeters: 400,
+        createdAt: new Date(),
+      };
+
+      const expectedEntity: School = {
+        id: 'new-id',
+        name: 'New School',
+        lat: 34.0522,
+        lng: -118.2437,
+        geofenceRadiusMeters: 800,
+        notificationThresholdMeters: 400,
+        createdAt: mockSavedModel.createdAt,
+      };
+
+      const mockModelData = {
+        name: 'New School',
+        lat: 34.0522,
+        lng: -118.2437,
+        location: 'POINT(-118.2437 34.0522)',
+        geofenceRadiusMeters: 800,
+        notificationThresholdMeters: 400,
+      };
+
+      jest.spyOn(SchoolMapper, 'toPersistence').mockReturnValue(mockModelData);
+      jest
+        .spyOn(schoolRepositoryMock, 'create')
+        .mockReturnValue(mockSavedModel);
+      jest
+        .spyOn(schoolRepositoryMock, 'save')
+        .mockResolvedValue(mockSavedModel);
+      jest.spyOn(SchoolMapper, 'toDomain').mockReturnValue(expectedEntity);
+
+      const result = await repository.create(createData);
+
+      expect(result).toEqual(expectedEntity);
+      expect(SchoolMapper.toPersistence).toHaveBeenCalledWith(createData);
+      expect(schoolRepositoryMock.create).toHaveBeenCalledWith(mockModelData);
+      expect(schoolRepositoryMock.save).toHaveBeenCalledWith(mockSavedModel);
+      expect(SchoolMapper.toDomain).toHaveBeenCalledWith(mockSavedModel);
+    });
+  });
+});

--- a/backend/src/data/repositories/school.repository.ts
+++ b/backend/src/data/repositories/school.repository.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SchoolModel } from '../models/school.model';
+import { SchoolMapper } from '../mappers/school.mapper';
+import { ISchoolRepository } from '../../domain/repositories/school.repository.interface';
+import { School } from '../../domain/entities/school.entity';
+
+@Injectable()
+export class SchoolRepository implements ISchoolRepository {
+  constructor(
+    @InjectRepository(SchoolModel)
+    private readonly schoolRepository: Repository<SchoolModel>,
+  ) {}
+
+  async findById(id: string): Promise<School | null> {
+    const model = await this.schoolRepository.findOne({ where: { id } });
+    return model ? SchoolMapper.toDomain(model) : null;
+  }
+
+  async create(data: Omit<School, 'id' | 'createdAt'>): Promise<School> {
+    const modelData = SchoolMapper.toPersistence(data);
+    const model = this.schoolRepository.create(modelData);
+    const savedModel = await this.schoolRepository.save(model);
+    return SchoolMapper.toDomain(savedModel);
+  }
+
+  async findAll(): Promise<School[]> {
+    const models = await this.schoolRepository.find();
+    return models.map(SchoolMapper.toDomain);
+  }
+
+  async update(id: string, data: Partial<School>): Promise<School> {
+    await this.schoolRepository.update(id, data);
+    const updatedModel = await this.schoolRepository.findOne({ where: { id } });
+    if (!updatedModel) {
+      throw new Error(`School with id ${id} not found after update`);
+    }
+    return SchoolMapper.toDomain(updatedModel);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.schoolRepository.delete(id);
+  }
+}

--- a/backend/src/domain/repositories/parent.repository.interface.ts
+++ b/backend/src/domain/repositories/parent.repository.interface.ts
@@ -10,5 +10,6 @@ export interface IParentRepository {
     data: Omit<Parent, 'id' | 'createdAt'> & { passwordHash: string },
   ): Promise<Parent>;
   update(id: string, data: Partial<Parent>): Promise<Parent>;
+  delete(id: string): Promise<void>;
   validateCredentials(email: string, password: string): Promise<Parent | null>;
 }

--- a/backend/src/domain/repositories/school.repository.interface.ts
+++ b/backend/src/domain/repositories/school.repository.interface.ts
@@ -5,5 +5,7 @@ export const SCHOOL_REPOSITORY = 'SCHOOL_REPOSITORY';
 export interface ISchoolRepository {
   findById(id: string): Promise<School | null>;
   create(data: Omit<School, 'id' | 'createdAt'>): Promise<School>;
+  findAll(): Promise<School[]>;
   update(id: string, data: Partial<School>): Promise<School>;
+  delete(id: string): Promise<void>;
 }


### PR DESCRIPTION
## TASK-008: Parent and School repository implementations

Implements concrete repository classes with mappers for data persistence:

### Files Implemented:
- **ParentRepository**: Implements IParentRepository with full CRUD operations
- **SchoolRepository**: Implements ISchoolRepository with full CRUD operations
- **ParentMapper**: Converts between ParentModel (TypeORM) and Parent (domain entity)
- **SchoolMapper**: Converts between SchoolModel (TypeORM) and School (domain entity)

### Key Features:
- PostGIS geography column handling in SchoolMapper
- Proper error handling and type safety
- NestJS dependency injection with custom tokens
- Unit tests for findById and create methods
- Repository pattern implementation

### Methods Implemented:

**ParentRepository:**
- findById(id: string): Promise<Parent | null>
- create(parent: Parent): Promise<Parent>
- findByEmail(email: string): Promise<Parent | null>
- update(parent: Parent): Promise<Parent>
- delete(id: string): Promise<void>

**SchoolRepository:**
- findById(id: string): Promise<School | null>
- create(school: School): Promise<School>
- findAll(): Promise<School[]>
- update(school: School): Promise<School>
- delete(id: string): Promise<void>

### Unit Tests:
- ✅ findById returns null for non-existent ID
- ✅ findById returns entity for existing ID
- ✅ create persists and returns new entity

### Definition of Done
- ✅ npx tsc --noEmit passes
- ✅ Unit tests for findById and create
- ✅ TypeScript validation passes
- ✅ Prettier formatting passes
- ✅ Proper error handling
- ✅ NestJS integration

Closes #10