### PR TITLE
feat: implement NotifySchoolUseCase

### DIFF
--- a/backend/src/domain/use-cases/notify-school.use-case.spec.ts
+++ b/backend/src/domain/use-cases/notify-school.use-case.spec.ts
@@ -1,0 +1,266 @@
+import { NotifySchoolUseCase } from './notify-school.use-case';
+import { GetSchoolArrivalsUseCase } from './get-school-arrivals.use-case';
+import { ISchoolRepository } from '../repositories/school.repository.interface';
+import { ArrivalsGateway } from '../../infrastructure/websocket/arrivals.gateway';
+import { School } from '../entities/school.entity';
+import { ETA } from '../entities/eta.entity';
+
+describe('NotifySchoolUseCase', () => {
+  let useCase: NotifySchoolUseCase;
+  let getSchoolArrivalsUseCaseMock: jest.Mocked<GetSchoolArrivalsUseCase>;
+  let schoolRepositoryMock: jest.Mocked<ISchoolRepository>;
+  let arrivalsGatewayMock: jest.Mocked<ArrivalsGateway>;
+
+  const mockSchool: School = {
+    id: 'school-456',
+    name: 'Springfield Elementary',
+    lat: -23.55052,
+    lng: -46.633308,
+    geofenceRadiusMeters: 500,
+    notificationThresholdMeters: 1000,
+    createdAt: new Date(),
+  };
+
+  const mockETA: ETA = {
+    id: 'eta-1',
+    parentId: 'parent-1',
+    schoolId: 'school-456',
+    durationSeconds: 900,
+    distanceMeters: 1200,
+    routePolyline: 'encoded_polyline_1',
+    calculatedAt: new Date(),
+  };
+
+  const mockArrivals = [
+    {
+      parentId: 'parent-1',
+      parentName: 'John Doe',
+      lat: -23.551,
+      lng: -46.634,
+      etaMinutes: 15,
+      distanceMeters: 1200,
+      calculatedAt: new Date(),
+    },
+  ];
+
+  const mockArrivalsOutput = {
+    schoolName: 'Springfield Elementary',
+    totalCount: 1,
+    arrivals: mockArrivals,
+  };
+
+  beforeEach(() => {
+    getSchoolArrivalsUseCaseMock = {
+      execute: jest.fn(),
+    } as any;
+
+    schoolRepositoryMock = {
+      findById: jest.fn(),
+      create: jest.fn(),
+      findAll: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findParentsWithinGeofence: jest.fn(),
+    } as any;
+
+    arrivalsGatewayMock = {
+      emitArrivalsUpdated: jest.fn(),
+    } as any;
+
+    useCase = new NotifySchoolUseCase(
+      getSchoolArrivalsUseCaseMock,
+      schoolRepositoryMock,
+      arrivalsGatewayMock,
+    );
+  });
+
+  describe('execute', () => {
+    it('should notify school with updated arrivals queue', async () => {
+      // Arrange
+      const input = {
+        schoolId: 'school-456',
+        parentId: 'parent-1',
+        eta: mockETA,
+      };
+
+      schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+      getSchoolArrivalsUseCaseMock.execute.mockResolvedValue(
+        mockArrivalsOutput,
+      );
+
+      // Act
+      await useCase.execute(input);
+
+      // Assert
+      expect(schoolRepositoryMock.findById).toHaveBeenCalledWith('school-456');
+      expect(getSchoolArrivalsUseCaseMock.execute).toHaveBeenCalledWith({
+        schoolId: 'school-456',
+      });
+      expect(arrivalsGatewayMock.emitArrivalsUpdated).toHaveBeenCalledWith(
+        'school-456',
+        mockArrivals,
+        'Springfield Elementary',
+      );
+    });
+
+    it('should throw error if school not found', async () => {
+      // Arrange
+      const input = {
+        schoolId: 'non-existent-school',
+        parentId: 'parent-1',
+        eta: mockETA,
+      };
+
+      schoolRepositoryMock.findById.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(useCase.execute(input)).rejects.toThrow(
+        'School with id non-existent-school not found',
+      );
+      expect(getSchoolArrivalsUseCaseMock.execute).not.toHaveBeenCalled();
+      expect(arrivalsGatewayMock.emitArrivalsUpdated).not.toHaveBeenCalled();
+    });
+
+    it('should emit event with empty arrivals when no parents in queue', async () => {
+      // Arrange
+      const input = {
+        schoolId: 'school-456',
+        parentId: 'parent-1',
+        eta: mockETA,
+      };
+
+      const emptyArrivalsOutput = {
+        schoolName: 'Springfield Elementary',
+        totalCount: 0,
+        arrivals: [],
+      };
+
+      schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+      getSchoolArrivalsUseCaseMock.execute.mockResolvedValue(
+        emptyArrivalsOutput,
+      );
+
+      // Act
+      await useCase.execute(input);
+
+      // Assert
+      expect(arrivalsGatewayMock.emitArrivalsUpdated).toHaveBeenCalledWith(
+        'school-456',
+        [],
+        'Springfield Elementary',
+      );
+    });
+
+    it('should propagate error from GetSchoolArrivalsUseCase', async () => {
+      // Arrange
+      const input = {
+        schoolId: 'school-456',
+        parentId: 'parent-1',
+        eta: mockETA,
+      };
+
+      const error = new Error('Failed to get arrivals');
+
+      schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+      getSchoolArrivalsUseCaseMock.execute.mockRejectedValue(error);
+
+      // Act & Assert
+      await expect(useCase.execute(input)).rejects.toThrow(
+        'Failed to get arrivals',
+      );
+      expect(arrivalsGatewayMock.emitArrivalsUpdated).not.toHaveBeenCalled();
+    });
+
+    it('should call gateway with correct school name', async () => {
+      // Arrange
+      const input = {
+        schoolId: 'school-456',
+        parentId: 'parent-1',
+        eta: mockETA,
+      };
+
+      const customSchool: School = {
+        ...mockSchool,
+        name: 'Custom School Name',
+      };
+
+      schoolRepositoryMock.findById.mockResolvedValue(customSchool);
+      getSchoolArrivalsUseCaseMock.execute.mockResolvedValue(
+        mockArrivalsOutput,
+      );
+
+      // Act
+      await useCase.execute(input);
+
+      // Assert
+      expect(arrivalsGatewayMock.emitArrivalsUpdated).toHaveBeenCalledWith(
+        'school-456',
+        mockArrivals,
+        'Custom School Name',
+      );
+    });
+
+    it('should handle multiple arrivals in queue', async () => {
+      // Arrange
+      const input = {
+        schoolId: 'school-456',
+        parentId: 'parent-1',
+        eta: mockETA,
+      };
+
+      const multipleArrivals = [
+        {
+          parentId: 'parent-1',
+          parentName: 'John Doe',
+          lat: -23.551,
+          lng: -46.634,
+          etaMinutes: 10,
+          distanceMeters: 1200,
+          calculatedAt: new Date(),
+        },
+        {
+          parentId: 'parent-2',
+          parentName: 'Jane Smith',
+          lat: -23.552,
+          lng: -46.635,
+          etaMinutes: 15,
+          distanceMeters: 1500,
+          calculatedAt: new Date(),
+        },
+        {
+          parentId: 'parent-3',
+          parentName: 'Bob Johnson',
+          lat: -23.553,
+          lng: -46.636,
+          etaMinutes: 20,
+          distanceMeters: 1800,
+          calculatedAt: new Date(),
+        },
+      ];
+
+      const multipleArrivalsOutput = {
+        schoolName: 'Springfield Elementary',
+        totalCount: 3,
+        arrivals: multipleArrivals,
+      };
+
+      schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+      getSchoolArrivalsUseCaseMock.execute.mockResolvedValue(
+        multipleArrivalsOutput,
+      );
+
+      // Act
+      await useCase.execute(input);
+
+      // Assert
+      expect(arrivalsGatewayMock.emitArrivalsUpdated).toHaveBeenCalledWith(
+        'school-456',
+        multipleArrivals,
+        'Springfield Elementary',
+      );
+      expect(
+        (arrivalsGatewayMock.emitArrivalsUpdated.mock.calls[0] as any)[1],
+      ).toHaveLength(3);
+    });
+  });
+});

--- a/backend/src/domain/use-cases/notify-school.use-case.ts
+++ b/backend/src/domain/use-cases/notify-school.use-case.ts
@@ -1,0 +1,38 @@
+import { GetSchoolArrivalsUseCase } from './get-school-arrivals.use-case';
+import { ISchoolRepository } from '../repositories/school.repository.interface';
+import { ETA } from '../entities/eta.entity';
+import { ArrivalsGateway } from '../../infrastructure/websocket/arrivals.gateway';
+
+export interface NotifySchoolInput {
+  schoolId: string;
+  parentId: string;
+  eta: ETA;
+}
+
+export class NotifySchoolUseCase {
+  constructor(
+    private readonly getSchoolArrivalsUseCase: GetSchoolArrivalsUseCase,
+    private readonly schoolRepository: ISchoolRepository,
+    private readonly arrivalsGateway: ArrivalsGateway,
+  ) {}
+
+  async execute(input: NotifySchoolInput): Promise<void> {
+    // Validate school exists
+    const school = await this.schoolRepository.findById(input.schoolId);
+    if (!school) {
+      throw new Error(`School with id ${input.schoolId} not found`);
+    }
+
+    // Get updated arrivals queue
+    const arrivalsOutput = await this.getSchoolArrivalsUseCase.execute({
+      schoolId: input.schoolId,
+    });
+
+    // Emit WebSocket event to school room
+    this.arrivalsGateway.emitArrivalsUpdated(
+      input.schoolId,
+      arrivalsOutput.arrivals,
+      school.name,
+    );
+  }
+}

--- a/backend/src/presentation/locations/locations.module.ts
+++ b/backend/src/presentation/locations/locations.module.ts
@@ -5,6 +5,7 @@ import { SaveLocationUseCase } from '../../domain/use-cases/save-location.use-ca
 import { CalculateETAUseCase } from '../../domain/use-cases/calculate-eta.use-case';
 import { GetArrivalsQueueUseCase } from '../../domain/use-cases/get-arrivals-queue.use-case';
 import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
+import { NotifySchoolUseCase } from '../../domain/use-cases/notify-school.use-case';
 import { DataModule } from '../../data/data.module';
 import { OSRMModule } from '../../infrastructure/osrm/osrm.module';
 import { WebSocketModule } from '../../infrastructure/websocket/websocket.module';
@@ -19,6 +20,7 @@ import { OSRMServiceAdapter } from '../../infrastructure/osrm/osrm-service.adapt
     CalculateETAUseCase,
     GetArrivalsQueueUseCase,
     GetSchoolArrivalsUseCase,
+    NotifySchoolUseCase,
     {
       provide: 'IOSRMServiceAdapter',
       useClass: OSRMServiceAdapter,

--- a/backend/src/presentation/locations/locations.service.spec.ts
+++ b/backend/src/presentation/locations/locations.service.spec.ts
@@ -3,6 +3,7 @@ import { LocationsService } from './locations.service';
 import { SaveLocationUseCase } from '../../domain/use-cases/save-location.use-case';
 import { CalculateETAUseCase } from '../../domain/use-cases/calculate-eta.use-case';
 import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
+import { NotifySchoolUseCase } from '../../domain/use-cases/notify-school.use-case';
 import {
   ILocationRepository,
   LOCATION_REPOSITORY,
@@ -29,6 +30,7 @@ describe('LocationsService', () => {
   let saveLocationUseCaseMock: jest.Mocked<SaveLocationUseCase>;
   let calculateETAUseCaseMock: jest.Mocked<CalculateETAUseCase>;
   let getSchoolArrivalsUseCaseMock: jest.Mocked<GetSchoolArrivalsUseCase>;
+  let notifySchoolUseCaseMock: jest.Mocked<NotifySchoolUseCase>;
   let locationRepositoryMock: jest.Mocked<ILocationRepository>;
   let etaRepositoryMock: jest.Mocked<IETARepository>;
   let parentRepositoryMock: jest.Mocked<IParentRepository>;
@@ -84,6 +86,10 @@ describe('LocationsService', () => {
       execute: jest.fn(),
     } as any;
 
+    notifySchoolUseCaseMock = {
+      execute: jest.fn(),
+    } as any;
+
     locationRepositoryMock = {
       save: jest.fn(),
       findById: jest.fn(),
@@ -135,6 +141,10 @@ describe('LocationsService', () => {
           useValue: getSchoolArrivalsUseCaseMock,
         },
         {
+          provide: NotifySchoolUseCase,
+          useValue: notifySchoolUseCaseMock,
+        },
+        {
           provide: LOCATION_REPOSITORY,
           useValue: locationRepositoryMock,
         },
@@ -166,6 +176,8 @@ describe('LocationsService', () => {
       const parentId = 'parent-456';
       saveLocationUseCaseMock.execute.mockResolvedValue(mockSaveLocationOutput);
       calculateETAUseCaseMock.execute.mockResolvedValue(mockCalculateETAOutput);
+      etaRepositoryMock.findLatestByParentId.mockResolvedValue(mockETA);
+      notifySchoolUseCaseMock.execute.mockResolvedValue(undefined);
 
       // Act
       const result = await service.saveLocation(parentId, createLocationDto);
@@ -180,6 +192,12 @@ describe('LocationsService', () => {
 
       expect(calculateETAUseCaseMock.execute).toHaveBeenCalledWith({
         parentId,
+      });
+
+      expect(notifySchoolUseCaseMock.execute).toHaveBeenCalledWith({
+        schoolId: 'school-123',
+        parentId,
+        eta: mockETA,
       });
 
       expect(result).toEqual({
@@ -207,6 +225,15 @@ describe('LocationsService', () => {
       calculateETAUseCaseMock.execute.mockRejectedValue(
         new Error('ETA calculation failed'),
       );
+      parentRepositoryMock.findById.mockResolvedValue({
+        id: parentId,
+        name: 'John Doe',
+        email: 'john@example.com',
+        phone: '+5511999999999',
+        schoolId: 'school-123',
+        createdAt: new Date(),
+      });
+      etaRepositoryMock.findLatestByParentId.mockResolvedValue(null);
 
       // Act
       const result = await service.saveLocation(parentId, createLocationDto);
@@ -214,6 +241,8 @@ describe('LocationsService', () => {
       // Assert
       expect(saveLocationUseCaseMock.execute).toHaveBeenCalled();
       expect(calculateETAUseCaseMock.execute).toHaveBeenCalled();
+      // NotifySchool should not be called if ETA not found
+      expect(notifySchoolUseCaseMock.execute).not.toHaveBeenCalled();
 
       // Should still return location data even if ETA calculation failed
       expect(result).toEqual({
@@ -251,6 +280,8 @@ describe('LocationsService', () => {
         mockSaveLocationOutputWithoutAccuracy,
       );
       calculateETAUseCaseMock.execute.mockResolvedValue(mockCalculateETAOutput);
+      etaRepositoryMock.findLatestByParentId.mockResolvedValue(mockETA);
+      notifySchoolUseCaseMock.execute.mockResolvedValue(undefined);
 
       // Act
       const result = await service.saveLocation(

--- a/backend/src/presentation/locations/locations.service.ts
+++ b/backend/src/presentation/locations/locations.service.ts
@@ -8,10 +8,8 @@ import {
   CalculateETAInput,
   CalculateETAOutput,
 } from '../../domain/use-cases/calculate-eta.use-case';
-import {
-  GetSchoolArrivalsUseCase,
-  GetSchoolArrivalsInput,
-} from '../../domain/use-cases/get-school-arrivals.use-case';
+import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
+import { NotifySchoolUseCase } from '../../domain/use-cases/notify-school.use-case';
 import { ILocationRepository } from '../../domain/repositories/location.repository.interface';
 import { IETARepository } from '../../domain/repositories/eta.repository.interface';
 import { IParentRepository } from '../../domain/repositories/parent.repository.interface';
@@ -32,6 +30,7 @@ export class LocationsService {
     private readonly saveLocationUseCase: SaveLocationUseCase,
     private readonly calculateETAUseCase: CalculateETAUseCase,
     private readonly getSchoolArrivalsUseCase: GetSchoolArrivalsUseCase,
+    private readonly notifySchoolUseCase: NotifySchoolUseCase,
     @Inject(LOCATION_REPOSITORY)
     private readonly locationRepository: ILocationRepository,
     @Inject(ETA_REPOSITORY)
@@ -113,37 +112,25 @@ export class LocationsService {
     schoolId: string,
   ): Promise<void> {
     try {
-      // Get parent info to verify schoolId
-      const parent = await this.parentRepository.findById(parentId);
-      if (!parent) {
-        this.logger.warn(`Parent ${parentId} not found for WebSocket emit`);
+      // Get latest ETA for the parent
+      const eta = await this.etaRepository.findLatestByParentId(parentId);
+      if (!eta) {
+        this.logger.warn(`No ETA found for parent ${parentId}`);
         return;
       }
 
-      // Get school info
-      const school = await this.schoolRepository.findById(schoolId);
-      if (!school) {
-        this.logger.warn(`School ${schoolId} not found for WebSocket emit`);
-        return;
-      }
-
-      // Get current arrivals queue
-      const arrivalsInput: GetSchoolArrivalsInput = { schoolId };
-      const arrivalsOutput =
-        await this.getSchoolArrivalsUseCase.execute(arrivalsInput);
-
-      // Emit to WebSocket room
-      this.arrivalsGateway.emitArrivalsUpdated(
+      // Use NotifySchoolUseCase to encapsulate the notification business logic
+      await this.notifySchoolUseCase.execute({
         schoolId,
-        arrivalsOutput.arrivals,
-        school.name,
-      );
+        parentId,
+        eta,
+      });
 
       this.logger.debug(
-        `Emitted arrivals update for school ${schoolId} (${arrivalsOutput.arrivals.length} arrivals)`,
+        `Notified school ${schoolId} about location update from parent ${parentId}`,
       );
     } catch (error) {
-      this.logger.error(`Failed to emit arrivals update: ${error.message}`);
+      this.logger.error(`Failed to notify school: ${error.message}`);
       // Don't throw - this is a side effect and shouldn't break the location save
     }
   }


### PR DESCRIPTION
Implements the NotifySchoolUseCase as planned in domain layer (TASK-10).

## Problem
The notification logic was scattered — the gateway emits updates but there's no formal use case encapsulating the business rule: 'when a parent's ETA is updated, notify the school's connected clients'.

## Solution
1. Create `NotifySchoolUseCase` in domain layer
2. Encapsulates: Get arrivals queue + emit WebSocket event
3. Inject into LocationsService and call after ETA calculation
4. Enables future extensions (FCM, email alerts) without touching controller

## Changes
- `src/domain/use-cases/notify-school.use-case.ts` (new)
- `src/domain/use-cases/notify-school.use-case.spec.ts` (new, full coverage)
- `src/presentation/locations/locations.service.ts` (wire use case)
- `src/presentation/locations/locations.module.ts` (register use case)

## Acceptance Criteria
- [x] NotifySchoolUseCase exists in domain layer
- [x] Called by LocationsService after ETA calculated
- [x] Unit tests cover happy path and failure scenarios
- [x] Gateway emission verified in tests

## Testing
- [x] All unit tests pass
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Build succeeds

Closes #36