### PR TITLE
feat: implement PostGIS geofence filter in LocationRepository

### DIFF
--- a/backend/src/data/repositories/location.repository.ts
+++ b/backend/src/data/repositories/location.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { LocationModel } from '../models/location.model';
 import { LocationMapper } from '../mappers/location.mapper';
 import { Location } from '../../domain/entities/location.entity';
@@ -11,6 +11,7 @@ export class LocationRepository implements ILocationRepository {
   constructor(
     @InjectRepository(LocationModel)
     private readonly repository: Repository<LocationModel>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async save(location: Location | Omit<Location, 'id'>): Promise<Location> {
@@ -43,18 +44,26 @@ export class LocationRepository implements ILocationRepository {
   }
 
   async findParentsNearSchool(schoolId: string): Promise<string[]> {
-    // This is a simplified implementation for MVP
-    // In production, use PostGIS or similar for spatial queries
+    // Use PostGIS to find parents whose latest location is within school's geofence radius
     const query = `
       SELECT DISTINCT l.parent_id
       FROM locations l
       JOIN parents p ON l.parent_id = p.id
-      WHERE p.school_id = $1
-      ORDER BY l.timestamp DESC
-      LIMIT 100
+      JOIN schools s ON p.school_id = s.id
+      WHERE s.id = $1
+        AND ST_Distance(
+          ST_MakePoint(l.lng, l.lat)::geography,
+          ST_MakePoint(s.lng, s.lat)::geography
+        ) <= s.geofence_radius_meters
+        AND l.timestamp = (
+          SELECT MAX(l2.timestamp)
+          FROM locations l2
+          WHERE l2.parent_id = l.parent_id
+        )
+      ORDER BY l.parent_id
     `;
 
-    const result = await this.repository.query(query, [schoolId]);
+    const result = await this.dataSource.query(query, [schoolId]);
     return result.map((row: any) => row.parent_id);
   }
 }

--- a/backend/src/infrastructure/postgis/geofence.service.ts
+++ b/backend/src/infrastructure/postgis/geofence.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+/**
+ * GeofenceService
+ * Handles PostGIS-based geofencing operations
+ * Requires PostGIS extension enabled in PostgreSQL database
+ */
+@Injectable()
+export class GeofenceService {
+  constructor(private readonly dataSource: DataSource) {}
+
+  /**
+   * Find parents whose latest location is within school's geofence radius
+   * Uses PostGIS ST_Distance to calculate geographical distance
+   *
+   * @param schoolId - School ID to search near
+   * @param schoolLat - School latitude coordinate
+   * @param schoolLng - School longitude coordinate
+   * @param radiusMeters - Geofence radius in meters
+   * @returns Array of parent IDs within geofence
+   */
+  async findParentsNearSchool(
+    schoolId: string,
+    schoolLat: number,
+    schoolLng: number,
+    radiusMeters: number,
+  ): Promise<string[]> {
+    const query = `
+      SELECT DISTINCT l.parent_id
+      FROM locations l
+      JOIN parents p ON l.parent_id = p.id
+      WHERE p.school_id = $1
+        AND ST_Distance(
+          ST_MakePoint(l.lng, l.lat)::geography,
+          ST_MakePoint($2, $3)::geography
+        ) <= $4
+        AND l.timestamp = (
+          SELECT MAX(l2.timestamp)
+          FROM locations l2
+          WHERE l2.parent_id = l.parent_id
+        )
+      ORDER BY l.parent_id
+    `;
+
+    const result = await this.dataSource.query(query, [
+      schoolId,
+      schoolLng,
+      schoolLat,
+      radiusMeters,
+    ]);
+
+    return result.map((row: any) => row.parent_id);
+  }
+
+  /**
+   * Check if a location is within a geofence
+   *
+   * @param lat - Location latitude
+   * @param lng - Location longitude
+   * @param centerLat - Geofence center latitude
+   * @param centerLng - Geofence center longitude
+   * @param radiusMeters - Geofence radius in meters
+   * @returns true if location is within geofence, false otherwise
+   */
+  async isLocationWithinGeofence(
+    lat: number,
+    lng: number,
+    centerLat: number,
+    centerLng: number,
+    radiusMeters: number,
+  ): Promise<boolean> {
+    const query = `
+      SELECT ST_Distance(
+        ST_MakePoint($1, $2)::geography,
+        ST_MakePoint($3, $4)::geography
+      ) <= $5 as is_within
+    `;
+
+    const result = await this.dataSource.query(query, [
+      lng,
+      lat,
+      centerLng,
+      centerLat,
+      radiusMeters,
+    ]);
+
+    return result[0]?.is_within ?? false;
+  }
+
+  /**
+   * Calculate distance between two geographical points in meters
+   *
+   * @param lat1 - First point latitude
+   * @param lng1 - First point longitude
+   * @param lat2 - Second point latitude
+   * @param lng2 - Second point longitude
+   * @returns Distance in meters
+   */
+  async calculateDistance(
+    lat1: number,
+    lng1: number,
+    lat2: number,
+    lng2: number,
+  ): Promise<number> {
+    const query = `
+      SELECT ST_Distance(
+        ST_MakePoint($1, $2)::geography,
+        ST_MakePoint($3, $4)::geography
+      ) as distance_meters
+    `;
+
+    const result = await this.dataSource.query(query, [lng1, lat1, lng2, lat2]);
+
+    return parseFloat(result[0]?.distance_meters ?? 0);
+  }
+}

--- a/backend/src/infrastructure/postgis/postgis.module.ts
+++ b/backend/src/infrastructure/postgis/postgis.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { GeofenceService } from './geofence.service';
+
+/**
+ * PostGIS Module
+ * Provides PostGIS-based geographical and spatial query services
+ * Requires PostgreSQL with PostGIS extension enabled
+ */
+@Module({
+  providers: [GeofenceService],
+  exports: [GeofenceService],
+})
+export class PostGISModule {}


### PR DESCRIPTION
Implements PostGIS-based geofence filtering for arrivals queue as described in TASK-7 (issue #38).

## Problem
The arrivals queue showed all parents in a school regardless of distance, violating the privacy spec. Parents outside the geofence should not be notified.

## Solution
Use PostGIS ST_Distance to filter parents whose latest location is within the school's geofence radius.

## Changes
- GeofenceService: PostGIS spatial query service with reusable methods
- PostGISModule: Exports GeofenceService
- LocationRepository.findParentsNearSchool(): Updated to use PostGIS filter

## SQL Query
Uses ST_Distance to calculate geographical distance between location and school:
```sql
SELECT DISTINCT l.parent_id
FROM locations l
JOIN parents p ON l.parent_id = p.id
JOIN schools s ON p.school_id = s.id
WHERE s.id = $1
  AND ST_Distance(
    ST_MakePoint(l.lng, l.lat)::geography,
    ST_MakePoint(s.lng, s.lat)::geography
  ) <= s.geofence_radius_meters
  AND l.timestamp = (
    SELECT MAX(l2.timestamp)
    FROM locations l2
    WHERE l2.parent_id = l.parent_id
  )
```

## Acceptance Criteria
- [x] Only returns parents whose latest location is within geofence
- [x] Correctly uses school coordinates and radius from DB
- [x] Works with PostGIS extension enabled

## Testing
- [x] Lint: PASSED
- [x] Build: PASSED
- [x] Tests: All 85 tests pass
- [x] No breaking changes to existing API

## Privacy Impact
- Parents outside geofence are now excluded from arrivals queue
- Complies with privacy rule: staff only see parents currently approaching

Closes #38