### PR TITLE
fix: correct inverted coordinates in SchoolRepository.findParentsWithinGeofence

### DIFF
--- a/backend/src/data/repositories/school.repository.ts
+++ b/backend/src/data/repositories/school.repository.ts
@@ -50,9 +50,8 @@ export class SchoolRepository implements ISchoolRepository {
       throw new Error(`School with id ${schoolId} not found`);
     }
 
-    // This is a simplified implementation for MVP
-    // In production, use PostGIS or similar for spatial queries
-    // Query to find parents within the school's geofence radius
+    // Query to find parents within the school's geofence radius using PostGIS
+    // Uses correct coordinate order: (longitude, latitude)
     const query = `
       SELECT DISTINCT p.id
       FROM parents p
@@ -66,7 +65,7 @@ export class SchoolRepository implements ISchoolRepository {
         )
         AND ST_Distance(
           ST_MakePoint($2, $3)::geography,
-          ST_MakePoint(l.lat, l.lng)::geography
+          ST_MakePoint(l.lng, l.lat)::geography
         ) <= $4
     `;
 


### PR DESCRIPTION
Fixes critical geofence filtering bug in SchoolRepository.

## Problem
`findParentsWithinGeofence` used `ST_MakePoint(l.lat, l.lng)` but PostGIS requires `(longitude, latitude)` order. This caused incorrect geofence filtering — parents outside the radius appeared in the arrivals queue.

## Solution
Correct the coordinate order to `ST_MakePoint(l.lng, l.lat)` to match PostGIS convention and `LocationRepository.findParentsNearSchool`.

## Impact
- **Security/Privacy:** Ensures only parents within geofence appear in arrivals queue
- **Correctness:** Fixes geographical calculations for distance filtering
- **Consistency:** Aligns with LocationRepository implementation

## Acceptance Criteria
- [x] findParentsWithinGeofence uses ST_MakePoint(lng, lat)
- [x] Coordinate order matches PostGIS convention and LocationRepository

## Testing
- [x] Lint: PASSED
- [x] Build: PASSED
- [x] Tests: PASSED (85 tests)

## Labels
- priority:high (geofence bug)
- bug (coordinate inversion)
- backend

Closes #51