### PR TITLE
chore: add ConfigModule and validate required env vars on startup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,18 +1,31 @@
-# App
-PORT=3000
+# Application Environment
 NODE_ENV=development
 
-# Database
-# In test environment (CI), PostgreSQL service is created with database 'onmyway_test'
-# In development, use 'onmyway'. Override with DATABASE_URL env var if needed.
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/onmyway_test
+# Server Port
+PORT=3000
 
-# Auth
-JWT_SECRET=change-this-to-a-secure-random-string
+# Database Connection
+# Format: postgresql://user:password@host:port/database
+# Example: postgresql://postgres:password@localhost:5432/onmyway
+DATABASE_URL=postgresql://postgres:password@localhost:5432/onmyway
+
+# JWT Secret for Authentication
+# IMPORTANT: Must be at least 32 characters for security
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+JWT_SECRET=your-super-secret-jwt-key-min-32-chars-long-please-change-me
+
+# JWT Token Expiration Time (optional)
+# Format: number (seconds) or string like '7d', '24h', '60m', '3600s'
+# Default: 7 days
 JWT_EXPIRES_IN=7d
 
-# OSRM (MVP: public server, Production: self-hosted)
-OSRM_BASE_URL=http://router.project-osrm.org
+# OSRM (Open Source Routing Machine) Configuration
+# Base URL for OSRM routing service
+# Local development: http://localhost:5000 or http://osrm:5000 (Docker)
+# Public: http://router.project-osrm.org (not recommended for production)
+OSRM_BASE_URL=http://osrm:5000
 
-# Redis (optional — phase 2)
-REDIS_URL=redis://localhost:6379
+# OSRM Timeout (optional)
+# Time in milliseconds to wait for OSRM response
+# Default: 10000 (10 seconds)
+OSRM_TIMEOUT_MS=10000

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@nestjs/common": "^11.0.0",
+        "@nestjs/config": "^4.0.3",
         "@nestjs/core": "^11.0.0",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.0",
@@ -20,6 +21,7 @@
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "joi": "^18.0.2",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.11.0",
@@ -844,6 +846,54 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2089,6 +2139,33 @@
         }
       }
     },
+    "node_modules/@nestjs/config": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.3.tgz",
+      "integrity": "sha512-FQ3M3Ohqfl+nHAn5tp7++wUQw0f2nAk+SFKe8EpNRnIifPqvfJP6JQxPKtFLMOHbyer4X646prFG4zSRYEssQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "17.2.3",
+        "dotenv-expand": "12.0.3",
+        "lodash": "4.17.23"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "11.1.17",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.17.tgz",
@@ -2445,6 +2522,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@tokenizer/inflate": {
@@ -4617,6 +4700,21 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
       },
@@ -7136,6 +7234,24 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7383,7 +7499,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.0.0",
+    "@nestjs/config": "^4.0.3",
     "@nestjs/core": "^11.0.0",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.0",
@@ -28,6 +29,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "joi": "^18.0.2",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.11.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { DatabaseModule } from './infrastructure/database/database.module';
 import { AuthModule } from './presentation/auth/auth.module';
@@ -6,9 +7,18 @@ import { OSRMModule } from './infrastructure/osrm/osrm.module';
 import { LocationsModule } from './presentation/locations/locations.module';
 import { SchoolsModule } from './presentation/schools/schools.module';
 import { WebSocketModule } from './infrastructure/websocket/websocket.module';
+import { validationSchema } from './infrastructure/config/validation.schema';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      validationSchema,
+      validationOptions: {
+        allowUnknown: true,
+        abortEarly: true,
+      },
+    }),
     DatabaseModule,
     AuthModule,
     OSRMModule,

--- a/backend/src/infrastructure/auth/jwt.constants.ts
+++ b/backend/src/infrastructure/auth/jwt.constants.ts
@@ -1,5 +1,5 @@
 // Parse JWT expiration time from env (e.g., '7d' -> 604800 seconds)
-function parseJwtExpiresIn(expiresIn: string | undefined): number {
+export function parseJwtExpiresIn(expiresIn: string | undefined): number {
   if (!expiresIn) return 60 * 60 * 24 * 7; // 7 days in seconds
 
   // Try to parse as number first
@@ -27,7 +27,5 @@ function parseJwtExpiresIn(expiresIn: string | undefined): number {
   }
 }
 
-export const JWT_CONSTANTS = {
-  secret: process.env.JWT_SECRET || 'change-this-to-a-secure-random-string',
-  expiresIn: parseJwtExpiresIn(process.env.JWT_EXPIRES_IN),
-};
+// JWT_CONSTANTS now computed from ConfigService in auth.module.ts
+// See: presentation/auth/auth.module.ts

--- a/backend/src/infrastructure/auth/jwt.strategy.ts
+++ b/backend/src/infrastructure/auth/jwt.strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { JWT_CONSTANTS } from './jwt.constants';
 import { JwtPayload } from './jwt-payload.interface';
 import { Parent } from '../../domain/entities/parent.entity';
 import {
@@ -15,11 +15,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     @Inject(PARENT_REPOSITORY)
     private readonly parentRepository: IParentRepository,
+    private readonly configService: ConfigService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: JWT_CONSTANTS.secret,
+      secretOrKey: configService.get<string>('JWT_SECRET'),
     });
   }
 

--- a/backend/src/infrastructure/config/validation.schema.ts
+++ b/backend/src/infrastructure/config/validation.schema.ts
@@ -1,0 +1,20 @@
+import * as Joi from 'joi';
+
+export const validationSchema = Joi.object({
+  NODE_ENV: Joi.string()
+    .valid('development', 'test', 'production')
+    .default('development'),
+  PORT: Joi.number().port().default(3000),
+  DATABASE_URL: Joi.string().required().messages({
+    'any.required': 'DATABASE_URL is required (postgres connection string)',
+  }),
+  JWT_SECRET: Joi.string().min(32).required().messages({
+    'any.required': 'JWT_SECRET is required',
+    'string.min':
+      'JWT_SECRET must be at least 32 characters (for security, use a strong random string)',
+  }),
+  OSRM_BASE_URL: Joi.string().uri().required().messages({
+    'any.required': 'OSRM_BASE_URL is required (e.g., http://osrm:5000)',
+    'string.uri': 'OSRM_BASE_URL must be a valid URI',
+  }),
+});

--- a/backend/src/infrastructure/osrm/osrm.module.ts
+++ b/backend/src/infrastructure/osrm/osrm.module.ts
@@ -1,4 +1,5 @@
 import { Module, Global } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { OSRMService } from './osrm.service';
 import { OSRMServiceAdapter } from './osrm-service.adapter';
 import { OSRMConfig } from './osrm.types';
@@ -11,9 +12,13 @@ import { OSRMConfig } from './osrm.types';
   providers: [
     {
       provide: 'OSRM_CONFIG',
-      useFactory: (): OSRMConfig => ({
-        baseUrl: process.env.OSRM_BASE_URL || 'http://router.project-osrm.org',
-        timeout: parseInt(process.env.OSRM_TIMEOUT_MS || '10000', 10),
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService): OSRMConfig => ({
+        baseUrl: configService.get<string>('OSRM_BASE_URL'),
+        timeout: parseInt(
+          configService.get<string>('OSRM_TIMEOUT_MS') || '10000',
+          10,
+        ),
       }),
     },
     OSRMService,

--- a/backend/src/presentation/auth/auth.module.ts
+++ b/backend/src/presentation/auth/auth.module.ts
@@ -1,19 +1,27 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
 import { DataModule } from '../../data/data.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from '../../infrastructure/auth/jwt.strategy';
-import { JWT_CONSTANTS } from '../../infrastructure/auth/jwt.constants';
+import { parseJwtExpiresIn } from '../../infrastructure/auth/jwt.constants';
 
 @Module({
   imports: [
     DataModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
-    JwtModule.register({
-      secret: JWT_CONSTANTS.secret,
-      signOptions: { expiresIn: JWT_CONSTANTS.expiresIn },
+    JwtModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: parseJwtExpiresIn(
+            configService.get<string>('JWT_EXPIRES_IN'),
+          ),
+        },
+      }),
     }),
   ],
   controllers: [AuthController],


### PR DESCRIPTION
Add environment variable validation and centralize configuration management.

## Context
The backend read process.env.* directly with no validation. If JWT_SECRET or DATABASE_URL are missing, the app boots silently and fails at runtime — potentially in production.

## Solution
Implemented @nestjs/config with Joi schema validation:

### Changes
1. Install dependencies: @nestjs/config and joi
2. Add ConfigModule.forRoot() with global scope in AppModule
3. Create validation.schema.ts with required env vars:
   - NODE_ENV: enum (development|test|production)
   - PORT: number, default 3000
   - DATABASE_URL: required postgres connection string
   - JWT_SECRET: required, min 32 characters (security)
   - OSRM_BASE_URL: required, must be valid URI
4. Refactored auth.module.ts to use JwtModule.registerAsync()
5. Updated jwt.strategy.ts to inject ConfigService
6. Updated osrm.module.ts to inject ConfigService for OSRM_CONFIG
7. Created comprehensive .env.example with all required variables

## Security Benefits
- JWT_SECRET validation: min 32 characters enforced at startup
- URI validation: OSRM_BASE_URL must be valid URI
- Required checks: DATABASE_URL fails app if missing
- Environment isolation: NODE_ENV validated against allowed values

## Test Results
✅ 103 tests passed (all existing tests still passing)
✅ npm run lint: PASSED
✅ npm run build: PASSED
✅ npm test: PASSED

## Acceptance Criteria
- [x] App fails fast with clear error if required env var is missing
- [x] JWT_SECRET shorter than 32 chars throws on startup
- [x] ConfigModule is global
- [x] .env.example reflects all required variables
- [x] npm run lint passes
- [x] npm run build passes
- [x] npm test passes (103/103)
- [x] PR references this issue

Closes #53