### PR TITLE
feat: add HealthModule with GET /health endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { OSRMModule } from './infrastructure/osrm/osrm.module';
 import { LocationsModule } from './presentation/locations/locations.module';
 import { SchoolsModule } from './presentation/schools/schools.module';
 import { WebSocketModule } from './infrastructure/websocket/websocket.module';
+import { HealthModule } from './presentation/health/health.module';
 import { validationSchema } from './infrastructure/config/validation.schema';
 
 @Module({
@@ -30,6 +31,7 @@ import { validationSchema } from './infrastructure/config/validation.schema';
     LocationsModule,
     SchoolsModule,
     WebSocketModule,
+    HealthModule,
   ],
   controllers: [AppController],
 })

--- a/backend/src/presentation/health/health.controller.ts
+++ b/backend/src/presentation/health/health.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, Injectable } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export interface HealthCheckResponse {
+  status: 'ok';
+  timestamp: string;
+  uptime: number;
+  service: string;
+  version: string;
+  checks: Record<string, string>;
+}
+
+@Injectable()
+export class HealthService {
+  getHealth(): HealthCheckResponse {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      uptime: Math.floor(process.uptime()),
+      service: 'onMyWay-api',
+      version: '1.0.0',
+      checks: {},
+    };
+  }
+}
+
+@ApiTags('health')
+@Controller('health')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Health check',
+    description: 'Check service health status',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Service is healthy',
+    schema: {
+      example: {
+        status: 'ok',
+        timestamp: '2026-03-23T16:37:00.000Z',
+        uptime: 3600,
+        service: 'onMyWay-api',
+        version: '1.0.0',
+        checks: {},
+      },
+    },
+  })
+  health(): HealthCheckResponse {
+    return this.healthService.getHealth();
+  }
+}

--- a/backend/src/presentation/health/health.module.ts
+++ b/backend/src/presentation/health/health.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { HealthController, HealthService } from './health.controller';
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}


### PR DESCRIPTION
## Description

Implements a dedicated `/health` endpoint for Mission Control and external monitoring tools to verify service availability.

## Changes

- ✅ New `HealthModule` in `backend/src/presentation/health/`
- ✅ `HealthService` with getHealth() method
- ✅ `HealthController` with GET /health endpoint (public, no JWT)
- ✅ Registered HealthModule in `app.module.ts`
- ✅ GET / endpoint remains unchanged

## Response Format (HTTP 200)

```json
{
  "status": "ok",
  "timestamp": "2026-03-23T16:37:00.000Z",
  "uptime": 3600,
  "service": "onMyWay-api",
  "version": "1.0.0",
  "checks": {}
}
```

## Acceptance Criteria

- ✅ GET /health returns HTTP 200
- ✅ Response includes status, timestamp, uptime, service, version, checks
- ✅ Endpoint is public (no JWT required)
- ✅ GET / continues to work as before

## Definition of Done

- ✅ npm run lint passes (0 warnings)
- ✅ npm run build passes
- ✅ npm test passes

Closes #80