### PR TITLE
feat: add database health check to GET /health

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { OSRMModule } from './infrastructure/osrm/osrm.module';
 import { LocationsModule } from './presentation/locations/locations.module';
 import { SchoolsModule } from './presentation/schools/schools.module';
 import { WebSocketModule } from './infrastructure/websocket/websocket.module';
+import { HealthModule } from './presentation/health/health.module';
 import { validationSchema } from './infrastructure/config/validation.schema';
 
 @Module({
@@ -30,6 +31,7 @@ import { validationSchema } from './infrastructure/config/validation.schema';
     LocationsModule,
     SchoolsModule,
     WebSocketModule,
+    HealthModule,
   ],
   controllers: [AppController],
 })

--- a/backend/src/presentation/health/health.controller.ts
+++ b/backend/src/presentation/health/health.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Get,
+  HttpStatus,
+  HttpException,
+  Injectable,
+} from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+export interface HealthCheckResponse {
+  status: 'ok' | 'error';
+  timestamp: string;
+  uptime: number;
+  service: string;
+  version: string;
+  checks: {
+    database: 'ok' | 'error';
+  };
+}
+
+@Injectable()
+export class HealthService {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async checkHealth(): Promise<HealthCheckResponse> {
+    const checks = {
+      database: await this.checkDatabase(),
+    };
+
+    const hasErrors = Object.values(checks).some((check) => check === 'error');
+    const status = hasErrors ? 'error' : 'ok';
+
+    return {
+      status,
+      timestamp: new Date().toISOString(),
+      uptime: Math.floor(process.uptime()),
+      service: 'onMyWay-api',
+      version: '1.0.0',
+      checks,
+    };
+  }
+
+  private async checkDatabase(): Promise<'ok' | 'error'> {
+    try {
+      if (!this.dataSource.isInitialized) {
+        return 'error';
+      }
+
+      await this.dataSource.query('SELECT 1');
+      return 'ok';
+    } catch {
+      return 'error';
+    }
+  }
+}
+
+@ApiTags('health')
+@Controller('health')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Health check',
+    description: 'Check service health and database connectivity',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Service is healthy',
+    schema: {
+      example: {
+        status: 'ok',
+        timestamp: '2026-03-23T16:37:00.000Z',
+        uptime: 3600,
+        service: 'onMyWay-api',
+        version: '1.0.0',
+        checks: {
+          database: 'ok',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Service is degraded',
+    schema: {
+      example: {
+        status: 'error',
+        timestamp: '2026-03-23T16:37:00.000Z',
+        uptime: 3600,
+        service: 'onMyWay-api',
+        version: '1.0.0',
+        checks: {
+          database: 'error',
+        },
+      },
+    },
+  })
+  async health(): Promise<HealthCheckResponse> {
+    const healthStatus = await this.healthService.checkHealth();
+
+    if (healthStatus.status === 'error') {
+      throw new HttpException(healthStatus, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    return healthStatus;
+  }
+}

--- a/backend/src/presentation/health/health.module.ts
+++ b/backend/src/presentation/health/health.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HealthController, HealthService } from './health.controller';
+
+@Module({
+  imports: [TypeOrmModule],
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}


### PR DESCRIPTION
## Description

Extends the `GET /health` endpoint (from #80) to report database connectivity status. Returns HTTP 503 when database is unreachable.

## Changes

- ✅ Extended `HealthService` with `checkDatabase()` method
- ✅ Updated `HealthController` to include DB check in response
- ✅ Throws HTTP 503 when database is unavailable
- ✅ Graceful error handling (no unhandled exceptions)

## Response — Healthy (HTTP 200)

```json
{
  "status": "ok",
  "timestamp": "...",
  "uptime": ...,
  "service": "onMyWay-api",
  "version": "1.0.0",
  "checks": {
    "database": "ok"
  }
}
```

## Response — Degraded (HTTP 503)

```json
{
  "status": "error",
  "timestamp": "...",
  "uptime": ...,
  "service": "onMyWay-api",
  "version": "1.0.0",
  "checks": {
    "database": "error"
  }
}
```

## Acceptance Criteria

- ✅ GET /health returns HTTP 200 with checks.database: 'ok' when DB is up
- ✅ GET /health returns HTTP 503 with checks.database: 'error' when DB is unreachable
- ✅ DB check uses SELECT 1 via TypeORM DataSource
- ✅ Connection failures are captured gracefully

## Definition of Done

- ✅ npm run lint passes (0 warnings)
- ✅ npm run build passes
- ✅ npm test passes

Closes #81