### PR TITLE
feat: define domain entities for mobile (Parent, School, Location, ETA)

### DIFF
--- a/mobile/src/domain/entities/current-location.entity.ts
+++ b/mobile/src/domain/entities/current-location.entity.ts
@@ -1,0 +1,10 @@
+/**
+ * CurrentLocation entity
+ * Represents the parent's current geographical location
+ */
+export interface CurrentLocation {
+  lat: number;
+  lng: number;
+  accuracy: number; // meters
+  timestamp: number; // unix ms
+}

--- a/mobile/src/domain/entities/eta.entity.ts
+++ b/mobile/src/domain/entities/eta.entity.ts
@@ -1,0 +1,10 @@
+/**
+ * ETA entity
+ * Represents estimated time of arrival and related route information
+ */
+export interface ETA {
+  parentId: string;
+  distanceMeters: number;
+  durationMinutes: number;
+  routePolyline: string; // encoded polyline
+}

--- a/mobile/src/domain/entities/index.ts
+++ b/mobile/src/domain/entities/index.ts
@@ -1,0 +1,4 @@
+export type { Parent } from './parent.entity';
+export type { School } from './school.entity';
+export type { CurrentLocation } from './current-location.entity';
+export type { ETA } from './eta.entity';

--- a/mobile/src/domain/entities/parent.entity.ts
+++ b/mobile/src/domain/entities/parent.entity.ts
@@ -1,0 +1,11 @@
+/**
+ * Parent entity
+ * Represents a parent/guardian user in the system
+ */
+export interface Parent {
+  id: string;
+  name: string;
+  phone: string;
+  email: string;
+  schoolId: string;
+}

--- a/mobile/src/domain/entities/school.entity.ts
+++ b/mobile/src/domain/entities/school.entity.ts
@@ -1,0 +1,12 @@
+/**
+ * School entity
+ * Represents a school/institution that parents are associated with
+ */
+export interface School {
+  id: string;
+  name: string;
+  location: {
+    lat: number;
+    lng: number;
+  };
+}


### PR DESCRIPTION
## Description

Defines the core domain entities for the mobile app as pure TypeScript interfaces. These entities drive the use cases and data layer, maintaining consistency with Clean Architecture principles.

## Entities Implemented

### Parent
- id: string (unique identifier)
- name: string (parent/guardian name)
- phone: string (contact number)
- email: string (email address)
- schoolId: string (associated school)

### School
- id: string (unique identifier)
- name: string (school name)
- location: { lat, lng } (GPS coordinates)

### CurrentLocation
- lat: number (latitude)
- lng: number (longitude)
- accuracy: number (GPS accuracy in meters)
- timestamp: number (unix timestamp in milliseconds)

### ETA
- parentId: string (parent reference)
- distanceMeters: number (route distance)
- durationMinutes: number (estimated duration)
- routePolyline: string (encoded polyline for route visualization)

## Structure

```
mobile/src/domain/entities/
├── parent.entity.ts
├── school.entity.ts
├── current-location.entity.ts
├── eta.entity.ts
└── index.ts
```

## Acceptance Criteria

- ✅ All 4 entities defined as TypeScript interfaces
- ✅ Exported from domain/entities/index.ts
- ✅ No imports from other layers
- ✅ npx tsc --noEmit passes

## Definition of Done

- ✅ npm run lint passes (0 warnings)
- ✅ npx tsc --noEmit passes
- ✅ Pure TypeScript (no business logic)

Closes #88