### PR TITLE
feat: useLocation and useSendLocation hooks for real-time location sharing

### DIFF
--- a/mobile/src/presentation/hooks/__tests__/useLocation.spec.ts
+++ b/mobile/src/presentation/hooks/__tests__/useLocation.spec.ts
@@ -1,0 +1,125 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useLocation } from '../useLocation';
+
+// Mock geolocation service
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('@infrastructure/geolocation', () => ({
+  geolocationService: {
+    startWatching: jest.fn((schoolLocation, onLocation, onError) => {
+      // Simulate location update after a small delay
+      setTimeout(() => {
+        const mockLocation = {
+          lat: -23.5505,
+          lng: -46.6333,
+          accuracy: 10,
+          timestamp: Date.now(),
+        };
+        onLocation(mockLocation, true); // within privacy radius
+      }, 10);
+
+      // Return unsubscribe function
+      return jest.fn();
+    }),
+    stopWatching: jest.fn(),
+  },
+}));
+
+describe('useLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should initialize with default state', () => {
+    const { result } = renderHook(() => useLocation());
+
+    expect(result.current.currentLocation).toBeNull();
+    expect(result.current.isTracking).toBe(false);
+    expect(result.current.withinPrivacyRadius).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should start tracking and receive location updates', async () => {
+    const { result } = renderHook(() => useLocation());
+    const schoolLocation = { lat: -23.5505, lng: -46.6333 };
+
+    await act(async () => {
+      result.current.startTracking(schoolLocation);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.isTracking).toBe(true);
+    expect(result.current.currentLocation).not.toBeNull();
+    expect(result.current.currentLocation?.lat).toBe(-23.5505);
+  });
+
+  it('should reflect withinPrivacyRadius from geolocation service', async () => {
+    const { result } = renderHook(() => useLocation());
+    const schoolLocation = { lat: -23.5505, lng: -46.6333 };
+
+    await act(async () => {
+      result.current.startTracking(schoolLocation);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.withinPrivacyRadius).toBe(true);
+  });
+
+  it('should stop tracking and cleanup', async () => {
+    const { result } = renderHook(() => useLocation());
+    const schoolLocation = { lat: -23.5505, lng: -46.6333 };
+
+    await act(async () => {
+      result.current.startTracking(schoolLocation);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.isTracking).toBe(true);
+
+    await act(async () => {
+      result.current.stopTracking();
+    });
+
+    expect(result.current.isTracking).toBe(false);
+    expect(result.current.currentLocation).toBeNull();
+    expect(result.current.withinPrivacyRadius).toBe(false);
+  });
+
+  it('should handle geolocation errors', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { geolocationService } = require('@infrastructure/geolocation');
+
+    geolocationService.startWatching.mockImplementationOnce(
+      (schoolLocation, onLocation, onError) => {
+        setTimeout(() => {
+          onError(new Error('Location permission denied'));
+        }, 10);
+        return jest.fn();
+      },
+    );
+
+    const { result } = renderHook(() => useLocation());
+    const schoolLocation = { lat: -23.5505, lng: -46.6333 };
+
+    await act(async () => {
+      result.current.startTracking(schoolLocation);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(result.current.error).toBe('Location permission denied');
+  });
+
+  it('should cleanup on unmount', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { geolocationService } = require('@infrastructure/geolocation');
+    const { result, unmount } = renderHook(() => useLocation());
+    const schoolLocation = { lat: -23.5505, lng: -46.6333 };
+
+    await act(async () => {
+      result.current.startTracking(schoolLocation);
+    });
+
+    unmount();
+
+    expect(geolocationService.stopWatching).toHaveBeenCalled();
+  });
+});

--- a/mobile/src/presentation/hooks/__tests__/useSendLocation.spec.ts
+++ b/mobile/src/presentation/hooks/__tests__/useSendLocation.spec.ts
@@ -1,0 +1,164 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useSendLocation } from '../useSendLocation';
+
+// Mock SendLocationUseCase
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('@domain/usecases', () => ({
+  SendLocationUseCase: jest.fn().mockImplementation(() => ({
+    execute: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+// Mock locationRepository
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+jest.mock('@data/repositories', () => ({
+  locationRepository: {
+    sendLocation: jest.fn(),
+  },
+}));
+
+describe('useSendLocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should initialize with default state', () => {
+    const { result } = renderHook(() => useSendLocation());
+
+    expect(result.current.isSending).toBe(false);
+    expect(result.current.lastSentAt).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should send location successfully', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SendLocationUseCase } = require('@domain/usecases');
+    const { result } = renderHook(() => useSendLocation());
+
+    const mockLocation = {
+      lat: -23.5505,
+      lng: -46.6333,
+      accuracy: 10,
+      timestamp: Date.now(),
+    };
+
+    await act(async () => {
+      await result.current.sendLocation('school1', mockLocation);
+    });
+
+    expect(SendLocationUseCase).toHaveBeenCalled();
+    expect(result.current.lastSentAt).not.toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should handle send errors gracefully', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SendLocationUseCase } = require('@domain/usecases');
+
+    SendLocationUseCase.mockImplementationOnce(() => ({
+      execute: jest.fn().mockRejectedValue(new Error('Network error')),
+    }));
+
+    const { result } = renderHook(() => useSendLocation());
+
+    const mockLocation = {
+      lat: -23.5505,
+      lng: -46.6333,
+      accuracy: 10,
+      timestamp: Date.now(),
+    };
+
+    await act(async () => {
+      try {
+        await result.current.sendLocation('school1', mockLocation);
+      } catch {
+        // Error expected
+      }
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.isSending).toBe(false);
+  });
+
+  it('should track lastSentAt timestamp', async () => {
+    const { result } = renderHook(() => useSendLocation());
+
+    const mockLocation = {
+      lat: -23.5505,
+      lng: -46.6333,
+      accuracy: 10,
+      timestamp: Date.now(),
+    };
+
+    const beforeSend = Date.now();
+
+    await act(async () => {
+      await result.current.sendLocation('school1', mockLocation);
+    });
+
+    const afterSend = Date.now();
+
+    expect(result.current.lastSentAt).toBeGreaterThanOrEqual(beforeSend);
+    expect(result.current.lastSentAt).toBeLessThanOrEqual(afterSend);
+  });
+
+  it('should prevent duplicate sends while one is in progress', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SendLocationUseCase } = require('@domain/usecases');
+
+    let resolveFirstSend: (() => void) | null = null;
+    const firstSendPromise = new Promise<void>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+
+    const mockExecute = jest.fn().mockImplementationOnce(
+      () => firstSendPromise,
+    );
+
+    SendLocationUseCase.mockImplementationOnce(() => ({
+      execute: mockExecute,
+    }));
+
+    const { result } = renderHook(() => useSendLocation());
+
+    const mockLocation = {
+      lat: -23.5505,
+      lng: -46.6333,
+      accuracy: 10,
+      timestamp: Date.now(),
+    };
+
+    // Start first send (don't await)
+    let firstSendResolved = false;
+    const send1Promise = result.current
+      .sendLocation('school1', mockLocation)
+      .then(() => {
+        firstSendResolved = true;
+      });
+
+    // Give it a moment to start
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    // Try to send while first is in progress - should return early
+    await act(async () => {
+      const send2Result = result.current.sendLocation('school1', mockLocation);
+      // This should return immediately if check is working
+      expect(result.current.isSending).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    // Only one execute should have been called
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+
+    // Complete the first send
+    if (resolveFirstSend) {
+      resolveFirstSend();
+    }
+
+    await act(async () => {
+      await send1Promise;
+    });
+  });
+});

--- a/mobile/src/presentation/hooks/index.ts
+++ b/mobile/src/presentation/hooks/index.ts
@@ -1,2 +1,6 @@
 export { useAuth } from './useAuth';
 export type { UseAuth } from './useAuth';
+export { useLocation } from './useLocation';
+export type { UseLocation } from './useLocation';
+export { useSendLocation } from './useSendLocation';
+export type { UseSendLocation } from './useSendLocation';

--- a/mobile/src/presentation/hooks/useLocation.ts
+++ b/mobile/src/presentation/hooks/useLocation.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect } from 'react';
+import { CurrentLocation } from '@domain/entities';
+import { geolocationService } from '@infrastructure/geolocation';
+
+export interface UseLocation {
+  currentLocation: CurrentLocation | null;
+  isTracking: boolean;
+  withinPrivacyRadius: boolean;
+  error: string | null;
+  startTracking(schoolLocation: { lat: number; lng: number }): void;
+  stopTracking(): void;
+}
+
+export const useLocation = (): UseLocation => {
+  const [currentLocation, setCurrentLocation] = useState<CurrentLocation | null>(null);
+  const [isTracking, setIsTracking] = useState(false);
+  const [withinPrivacyRadius, setWithinPrivacyRadius] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [unsubscribe, setUnsubscribe] = useState<(() => void) | null>(null);
+
+  const startTracking = (schoolLocation: { lat: number; lng: number }) => {
+    setIsTracking(true);
+    setError(null);
+
+    const stopFn = geolocationService.startWatching(
+      schoolLocation,
+      (location, withinRadius) => {
+        setCurrentLocation(location);
+        setWithinPrivacyRadius(withinRadius);
+      },
+      (err) => {
+        setError(err.message);
+      },
+    );
+
+    setUnsubscribe(() => stopFn);
+  };
+
+  const stopTracking = () => {
+    if (unsubscribe) {
+      unsubscribe();
+      setUnsubscribe(null);
+    }
+    geolocationService.stopWatching();
+    setIsTracking(false);
+    setCurrentLocation(null);
+    setWithinPrivacyRadius(false);
+    setError(null);
+  };
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+      geolocationService.stopWatching();
+    };
+  }, [unsubscribe]);
+
+  return {
+    currentLocation,
+    isTracking,
+    withinPrivacyRadius,
+    error,
+    startTracking,
+    stopTracking,
+  };
+};

--- a/mobile/src/presentation/hooks/useSendLocation.ts
+++ b/mobile/src/presentation/hooks/useSendLocation.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { CurrentLocation } from '@domain/entities';
+import { SendLocationUseCase } from '@domain/usecases';
+import { locationRepository } from '@data/repositories';
+
+export interface UseSendLocation {
+  isSending: boolean;
+  lastSentAt: number | null;
+  error: string | null;
+  sendLocation(schoolId: string, location: CurrentLocation): Promise<void>;
+}
+
+export const useSendLocation = (): UseSendLocation => {
+  const [isSending, setIsSending] = useState(false);
+  const [lastSentAt, setLastSentAt] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const sendLocation = async (schoolId: string, location: CurrentLocation) => {
+    if (isSending) return; // Prevent duplicate sends
+
+    setIsSending(true);
+    setError(null);
+
+    try {
+      // Use the SendLocationUseCase
+      const useCase = new SendLocationUseCase(locationRepository);
+      await useCase.execute(schoolId, location);
+
+      setLastSentAt(Date.now());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to send location';
+      setError(message);
+      throw err;
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return {
+    isSending,
+    lastSentAt,
+    error,
+    sendLocation,
+  };
+};


### PR DESCRIPTION
## Description

Implements React hooks for real-time location sharing. useLocation manages GPS tracking with privacy gate awareness, while useSendLocation handles sending locations to the backend with duplicate prevention.

## useLocation Hook

Manages geolocation tracking with privacy awareness.

State:
- currentLocation: CurrentLocation or null
- isTracking: boolean
- withinPrivacyRadius: boolean (from GeolocationService)
- error: string or null

Methods:
- startTracking(schoolLocation) - Begin GPS updates every 10 seconds
- stopTracking() - Stop updates and cleanup

Behavior:
- Delegates to GeolocationService.startWatching()
- Updates state on each location callback
- Automatically cleans up on unmount
- Privacy radius passed through from geolocation service

## useSendLocation Hook

Handles sending parent location to backend via SendLocationUseCase.

State:
- isSending: boolean
- lastSentAt: number or null (unix milliseconds)
- error: string or null

Methods:
- sendLocation(schoolId, location) - Send location to backend

Behavior:
- Creates SendLocationUseCase instance
- Prevents duplicate sends while one is in progress
- Tracks timestamp of last successful send
- Throws on error (caller can gate with withinPrivacyRadius)

## Test Coverage (11 tests)

useLocation (6 tests):
- Initialize with default state
- Start tracking and receive updates
- Reflect withinPrivacyRadius from service
- Stop tracking and cleanup
- Handle geolocation errors
- Cleanup on unmount

useSendLocation (5 tests):
- Initialize with default state
- Send location successfully
- Handle send errors gracefully
- Track lastSentAt timestamp
- Prevent duplicate sends

## Integration

- Integrates with GeolocationService for GPS tracking
- Integrates with SendLocationUseCase for API calls
- Uses locationRepository for data layer
- Respects privacy gate (caller must check withinPrivacyRadius)

## Definition of Done

- ✅ startTracking() starts updates and populates currentLocation
- ✅ withinPrivacyRadius reflects privacy gate
- ✅ stopTracking() halts updates and cleans up
- ✅ sendLocation() calls SendLocationUseCase correctly
- ✅ Hooks clean up subscriptions on unmount
- ✅ npm run lint → 0 warnings
- ✅ npx tsc --noEmit → passes
- ✅ npm test → 11/11 tests passing

Closes #103