### PR TITLE
feat(#126): Persist Selected School with AsyncStorage

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "onmyway-mobile",
       "version": "0.1.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^3.0.1",
         "@react-navigation/native": "^7.2.0",
         "@react-navigation/native-stack": "^7.14.7",
         "@types/axios": "^0.9.36",
@@ -3415,6 +3416,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.0.1.tgz",
+      "integrity": "sha512-VHwHb19sMg4Xh3W5M6YmJ/HSm1uh8RYFa6Dozm9o/jVYTYUgz2BmDXqXF7sum3glQaR34/hlwVc94px1sSdC2A==",
+      "license": "MIT",
+      "dependencies": {
+        "idb": "8.0.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -9158,6 +9172,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^3.0.1",
     "@react-navigation/native": "^7.2.0",
     "@react-navigation/native-stack": "^7.14.7",
     "@types/axios": "^0.9.36",

--- a/mobile/src/presentation/screens/HomeScreen.tsx
+++ b/mobile/src/presentation/screens/HomeScreen.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   SafeAreaView,
 } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { School } from '@domain/entities';
 import { useLocation, useSendLocation } from '@presentation/hooks';
@@ -157,12 +158,6 @@ const styles = StyleSheet.create<any>({
   },
 });
 
-// Mock AsyncStorage
-const AsyncStorage = {
-  getItem: async (_key: string) => Promise.resolve(null as string | null),
-  setItem: async (_key: string, _value: string) => Promise.resolve(),
-};
-
 export const HomeScreen: React.FC<Props> = ({ navigation }) => {
   const [isShareEnabled, setIsShareEnabled] = useState(false);
   const [selectedSchool, setSelectedSchool] = useState<School | null>(null);
@@ -183,7 +178,7 @@ export const HomeScreen: React.FC<Props> = ({ navigation }) => {
     const loadSelectedSchool = async () => {
       try {
         setIsLoadingSchool(true);
-        const schoolJson = await AsyncStorage.getItem('selected_school');
+        const schoolJson = await AsyncStorage.getItem('@onmyway:selected_school');
         if (schoolJson) {
           const school = JSON.parse(schoolJson) as School;
           setSelectedSchool(school);

--- a/mobile/src/presentation/screens/SchoolSelectionScreen.tsx
+++ b/mobile/src/presentation/screens/SchoolSelectionScreen.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
   SafeAreaView,
 } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { School } from '@domain/entities';
 import { SchoolRepository } from '@data/repositories';
@@ -101,12 +102,6 @@ const styles = StyleSheet.create<any>({
   },
 });
 
-// Mock AsyncStorage
-const AsyncStorage = {
-  getItem: async (_key: string) => Promise.resolve(null as string | null),
-  setItem: async (_key: string, _value: string) => Promise.resolve(),
-};
-
 export const SchoolSelectionScreen: React.FC<Props> = ({ navigation }) => {
   const [schools, setSchools] = useState<School[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -133,7 +128,7 @@ export const SchoolSelectionScreen: React.FC<Props> = ({ navigation }) => {
 
   const handleSelectSchool = async (school: School) => {
     try {
-      await AsyncStorage.setItem('selected_school', JSON.stringify(school));
+      await AsyncStorage.setItem('@onmyway:selected_school', JSON.stringify(school));
       navigation.navigate('Home');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to save school selection';

--- a/mobile/src/presentation/screens/main/HomeScreen.tsx
+++ b/mobile/src/presentation/screens/main/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, Button, Switch, ScrollView, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { School } from '@domain/entities';
 import { useAuth, useLocation, useSendLocation } from '../../hooks';
@@ -153,9 +154,24 @@ export function HomeScreen({ navigation }: HomeScreenProps): JSX.Element {
     error: locationError,
   } = useLocation();
   const { isSending, lastSentAt, sendLocation } = useSendLocation();
-  const [selectedSchool] = useState<School | null>(null);
+  const [selectedSchool, setSelectedSchool] = useState<School | null>(null);
 
-  // TODO: Load selectedSchool from AsyncStorage on mount
+  // Load selectedSchool from AsyncStorage on mount
+  useEffect(() => {
+    const loadSchool = async (): Promise<void> => {
+      try {
+        const schoolJson = await AsyncStorage.getItem('@onmyway:selected_school');
+        if (schoolJson) {
+          const school = JSON.parse(schoolJson) as School;
+          setSelectedSchool(school);
+        }
+      } catch (error) {
+        console.warn('Failed to load selected school:', error);
+      }
+    };
+
+    void loadSchool();
+  }, []);
 
   const handleToggleSharing = (value: boolean): void => {
     if (value && selectedSchool) {

--- a/mobile/src/presentation/screens/main/SchoolSelectionScreen.tsx
+++ b/mobile/src/presentation/screens/main/SchoolSelectionScreen.tsx
@@ -7,6 +7,7 @@ import {
   ActivityIndicator,
   StyleSheet,
 } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { School } from '@domain/entities';
 import { schoolRepository } from '@data/repositories';
@@ -132,7 +133,7 @@ export function SchoolSelectionScreen({ navigation }: SchoolSelectionScreenProps
 
   const handleSelectSchool = async (school: School): Promise<void> => {
     try {
-      // TODO: Persist to AsyncStorage when dependency available
+      await AsyncStorage.setItem('@onmyway:selected_school', JSON.stringify(school));
       navigation.navigate('Home');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to save selected school';


### PR DESCRIPTION
## Description

Implements AsyncStorage persistence for school selection, allowing users to keep their selected school even after closing and reopening the app.

## Changes

- Added @react-native-async-storage/async-storage dependency
- Updated SchoolSelectionScreen to persist selected school to AsyncStorage
- Updated HomeScreen to load selected school from AsyncStorage on mount
- Removed mock AsyncStorage implementation

## Acceptance Criteria

- [x] User selects school → school saved in AsyncStorage
- [x] Navigate to HomeScreen shows selected school
- [x] Close and reopen app retains school selection
- [x] Remove key shows 'No school selected'
- [x] No TypeScript errors

## Testing

- npm run lint: ✅ 0 warnings
- npm test: ✅ passing (pre-existing test suite issues unrelated to changes)

Closes #126