### PR TITLE
feat: add View Map button to HomeScreen

### DIFF
--- a/mobile/src/presentation/screens/main/HomeScreen.tsx
+++ b/mobile/src/presentation/screens/main/HomeScreen.tsx
@@ -133,6 +133,9 @@ const styles = StyleSheet.create({
     color: '#991b1b',
     fontSize: 14,
   },
+  mapButtonContainer: {
+    marginBottom: 16,
+  },
   navigationButtons: {
     flexDirection: 'row',
     gap: 8,
@@ -288,6 +291,15 @@ export function HomeScreen({ navigation }: HomeScreenProps): JSX.Element {
                 <Text style={styles.errorText}>Error: {locationError}</Text>
               </View>
             )}
+
+            {/* View Map Button */}
+            <View style={styles.mapButtonContainer}>
+              <Button
+                title="View Map"
+                onPress={() => navigation.navigate('Map', { schoolId: selectedSchool.id })}
+                disabled={isSending}
+              />
+            </View>
 
             {/* Navigation Buttons */}
             <View style={styles.navigationButtons}>

--- a/mobile/src/presentation/screens/main/HomeScreen.tsx
+++ b/mobile/src/presentation/screens/main/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, Switch, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, Button, Switch, ScrollView, StyleSheet, TouchableOpacity } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { School } from '@domain/entities';
@@ -144,6 +144,19 @@ const styles = StyleSheet.create({
   buttonContainer: {
     flex: 1,
   },
+  mapButton: {
+    backgroundColor: '#2563eb',
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    marginBottom: 16,
+    alignItems: 'center',
+  },
+  mapButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
 });
 
 export function HomeScreen({ navigation }: HomeScreenProps): JSX.Element {
@@ -269,6 +282,16 @@ export function HomeScreen({ navigation }: HomeScreenProps): JSX.Element {
                 />
               </View>
             </View>
+
+            {/* View Map Button */}
+            {selectedSchool && (
+              <TouchableOpacity
+                style={styles.mapButton}
+                onPress={() => navigation.navigate('Map', { schoolId: selectedSchool.id })}
+              >
+                <Text style={styles.mapButtonText}>View Map</Text>
+              </TouchableOpacity>
+            )}
 
             {/* Status Badge */}
             <View style={[styles.statusBadge, statusBadge.container]}>


### PR DESCRIPTION
## Summary

Add a 'View Map' button to HomeScreen that navigates to MapScreen with the selected school's ID.

## Changes

- Add 'View Map' button below the location sharing toggle
- Button navigates to MapScreen with schoolId parameter
- Button only visible when a school is selected
- Apply blue button styling consistent with design system

## Acceptance Criteria

- [x] HomeScreen shows 'View Map' when school is selected
- [x] Tap on 'View Map' opens MapScreen with school ID
- [x] Button not visible when no school is selected
- [x] npm run lint: 0 warnings
- [x] npm test: passing tests

Closes #128