### PR TITLE
refactor(#129): useArrivals hook — use singleton instances

### DIFF
--- a/mobile/src/presentation/hooks/useArrivals.ts
+++ b/mobile/src/presentation/hooks/useArrivals.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { ETA } from '@domain/entities';
 import { GetArrivalsUseCase } from '@domain/usecases';
 import { schoolRepository } from '@data/repositories';
@@ -11,32 +11,39 @@ export interface UseArrivals {
   refresh(schoolId: string): Promise<void>;
 }
 
+// Create singleton instance of use case outside hook
+const getArrivalsUseCase = new GetArrivalsUseCase(schoolRepository);
+
 export const useArrivals = (): UseArrivals => {
   const { parent } = useAuth();
   const [eta, setEta] = useState<ETA | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const refresh = async (schoolId: string) => {
-    if (!parent) return;
+  const refresh = useCallback(
+    async (schoolId: string): Promise<void> => {
+      if (!parent) {
+        return;
+      }
 
-    setIsLoading(true);
-    setError(null);
+      setIsLoading(true);
+      setError(null);
 
-    try {
-      const useCase = new GetArrivalsUseCase(schoolRepository);
-      const arrivals = await useCase.execute(schoolId);
+      try {
+        const arrivals = await getArrivalsUseCase.execute(schoolId);
 
-      // Find current parent's ETA
-      const parentEta = arrivals.find((arr) => arr.parentId === parent.id);
-      setEta(parentEta || null);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to fetch ETA';
-      setError(message);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+        // Find current parent's ETA from the queue
+        const parentEta = arrivals.find((arr: ETA) => arr.parentId === parent.id);
+        setEta(parentEta || null);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to fetch ETA';
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [parent],
+  );
 
   return {
     eta,


### PR DESCRIPTION
## Summary
Refactors the `useArrivals` hook to instantiate the `GetArrivalsUseCase` and use the `schoolRepository` singleton at the module level instead of creating new instances on each render.

## Changes
- Moves `GetArrivalsUseCase` instantiation to module-level scope
- Creates singleton instance of `getArrivalsUseCase` at module import time
- Updates `refresh` callback to use `useCallback` with proper dependency array
- Eliminates unnecessary object recreations during hook execution

## Acceptance Criteria
- [x] useArrivals hook does not create SchoolRepository or GetArrivalsUseCase within refresh
- [x] ETA polling functions correctly
- [x] No TypeScript errors
- [x] npm run lint passes with 0 warnings
- [x] npm test passes

Closes #129