### PR TITLE
fix(mobile): remove @types/react-native (types bundled in RN 0.76)

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -40,7 +40,6 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.0",
     "@types/react": "~18.3.12",
-    "@types/react-native": "~0.76.0",
     "babel-jest": "^29.7.0",
     "babel-preset-expo": "~12.0.9",
     "eslint": "^8.50.0",


### PR DESCRIPTION
@types/react-native foi publicado apenas até a versão 0.73.0. A partir do RN 0.73+, os tipos já vêm embutidos no próprio pacote react-native.