### PR TITLE
fix(mobile): add index.js with registerRootComponent

### DIFF
--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './app';
+
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "onmyway-mobile",
   "version": "0.1.0",
   "description": "OnMyWay mobile app",
-  "main": "app.tsx",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "start:clear": "expo start --clear",


### PR DESCRIPTION
## Root Cause

`app.tsx` é um default export mas não chama `registerRootComponent`. Com expo 54.0.33 + RN 0.81.5, o framework não faz mais o wrap automático, causando:

> App entry not found — The app entry point named "main" was not registered.

## Fix

- Criado `index.js` que chama `registerRootComponent(App)` explicitamente
- `package.json` `main` atualizado para `index.js`

## Test plan

- [ ] `git pull origin develop`
- [ ] `expo start --clear`
- [ ] App deve abrir sem "App entry not found"