### PR TITLE
fix(mobile): remove duplicate initialize() and guard auth catch block

### DIFF
--- a/mobile/src/presentation/navigation/AppNavigator.tsx
+++ b/mobile/src/presentation/navigation/AppNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { View, ActivityIndicator } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { useAuth } from '@presentation/hooks';
@@ -6,12 +6,7 @@ import { AuthNavigator } from './AuthNavigator';
 import { MainNavigator } from './MainNavigator';
 
 export const AppNavigator: React.FC = () => {
-  const { isAuthenticated, isLoading, initialize } = useAuth();
-
-  // Initialize auth on mount
-  useEffect(() => {
-    initialize();
-  }, [initialize]);
+  const { isAuthenticated, isLoading } = useAuth();
 
   // Loading state: show spinner while auth is initializing
   if (isLoading) {

--- a/mobile/src/presentation/store/auth.store.ts
+++ b/mobile/src/presentation/store/auth.store.ts
@@ -125,8 +125,12 @@ export const useAuthStore = create<AuthStoreState>((set) => {
         });
       } catch {
         // Token invalid or expired, clear it
-        const tokenSvc = getTokenService();
-        await tokenSvc.clear();
+        try {
+          const tokenSvc = getTokenService();
+          await tokenSvc.clear();
+        } catch {
+          // ignore clear errors
+        }
         set({
           isAuthenticated: false,
           parent: null,


### PR DESCRIPTION
## Summary

- Remove `useEffect` duplicado em `AppNavigator` — `useAuth` já chama `initialize()` internamente
- Envolver `tokenSvc.clear()` no catch do auth store em try/catch para garantir que `isLoading` sempre volta para `false`

Esses dois problemas combinados causavam o spinner de loading ficar preso indefinidamente.

## Test plan

- [ ] `git pull origin develop`
- [ ] `expo start --clear`
- [ ] App deve passar do spinner e mostrar a tela de login