### PR TITLE
fix(mobile): comprehensive startup fixes for Expo Go

### DIFF
--- a/mobile/src/presentation/hooks/useAuth.ts
+++ b/mobile/src/presentation/hooks/useAuth.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useAuthStore } from '../store/auth.store';
 import { Parent } from '@domain/entities';
 
@@ -16,11 +15,6 @@ export interface UseAuth {
 export const useAuth = (): UseAuth => {
   const { isAuthenticated, parent, isLoading, error, login, register, logout, initialize } =
     useAuthStore();
-
-  // Initialize auth on app start
-  useEffect(() => {
-    initialize();
-  }, [initialize]);
 
   return {
     isAuthenticated,

--- a/mobile/src/presentation/hooks/useNotifications.ts
+++ b/mobile/src/presentation/hooks/useNotifications.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import * as Notifications from 'expo-notifications';
 import { fcmService, type RemoteMessage } from '@infrastructure/notifications';
 
@@ -8,23 +8,25 @@ export interface UseNotifications {
   requestPermission(): Promise<void>;
 }
 
-// Configure how to handle notifications when app is in foreground
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldShowAlert: true,
-    shouldPlaySound: true,
-    shouldSetBadge: false,
-    shouldShowBanner: true,
-    shouldShowList: true,
-  }),
-});
-
 export const useNotifications = (): UseNotifications => {
   const [fcmToken, setFcmToken] = useState<string | null>(null);
   const [permissionGranted, setPermissionGranted] = useState(false);
+  const handlerConfigured = useRef(false);
 
   // Request permission and get token on mount
   useEffect(() => {
+    // Configure notification handler once inside the effect, not at module level
+    if (!handlerConfigured.current) {
+      handlerConfigured.current = true;
+      Notifications.setNotificationHandler({
+        handleNotification: async () => ({
+          shouldShowAlert: true,
+          shouldPlaySound: true,
+          shouldSetBadge: false,
+        }),
+      });
+    }
+
     const initializeNotifications = async (): Promise<() => void> => {
       try {
         // Request FCM permission

--- a/mobile/src/presentation/navigation/AppNavigator.tsx
+++ b/mobile/src/presentation/navigation/AppNavigator.tsx
@@ -1,26 +1,62 @@
-import React from 'react';
-import { View, ActivityIndicator } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
-import { useAuth } from '@presentation/hooks';
+import { useAuth } from '../hooks/useAuth';
 import { AuthNavigator } from './AuthNavigator';
 import { MainNavigator } from './MainNavigator';
 
-export const AppNavigator: React.FC = () => {
-  const { isAuthenticated, isLoading } = useAuth();
+const INIT_TIMEOUT_MS = 5000;
 
-  // Loading state: show spinner while auth is initializing
-  if (isLoading) {
+export const AppNavigator: React.FC = () => {
+  const { isAuthenticated, isLoading, initialize } = useAuth();
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    let timedOut = false;
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      setInitialized(true);
+    }, INIT_TIMEOUT_MS);
+
+    initialize()
+      .catch(() => {})
+      .finally(() => {
+        if (!timedOut) {
+          clearTimeout(timeout);
+          setInitialized(true);
+        }
+      });
+
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!initialized || isLoading) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <View style={styles.loading}>
         <ActivityIndicator size="large" color="#2563eb" />
+        <Text style={styles.loadingText}>Loading...</Text>
       </View>
     );
   }
 
-  // Route based on authentication state
   return (
     <NavigationContainer>
       {isAuthenticated ? <MainNavigator /> : <AuthNavigator />}
     </NavigationContainer>
   );
 };
+
+const styles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+  },
+  loadingText: {
+    marginTop: 12,
+    fontSize: 14,
+    color: '#6b7280',
+  },
+});

--- a/mobile/src/presentation/screens/auth/LoginScreen.tsx
+++ b/mobile/src/presentation/screens/auth/LoginScreen.tsx
@@ -10,7 +10,7 @@ import {
   SafeAreaView,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useAuth } from '@presentation/hooks';
+import { useAuth } from '@presentation/hooks/useAuth';
 import { AuthStackParamList } from '@presentation/navigation/types';
 
 type LoginScreenNavigationProp = NativeStackNavigationProp<AuthStackParamList, 'Login'>;

--- a/mobile/src/presentation/screens/auth/RegisterScreen.tsx
+++ b/mobile/src/presentation/screens/auth/RegisterScreen.tsx
@@ -10,7 +10,7 @@ import {
   SafeAreaView,
 } from 'react-native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useAuth } from '@presentation/hooks';
+import { useAuth } from '@presentation/hooks/useAuth';
 import { AuthStackParamList } from '@presentation/navigation/types';
 
 type RegisterScreenNavigationProp = NativeStackNavigationProp<AuthStackParamList, 'Register'>;


### PR DESCRIPTION
## Root Cause Analysis

O app travava no spinner de loading por uma combinação de problemas:

### 1. Barrel import cascade
`AppNavigator` importava `useAuth` do barrel `@presentation/hooks`. Isso forçava o carregamento de **todos** os hooks, incluindo `useNotifications` que executa `Notifications.setNotificationHandler()` no nível do módulo — código incompatível com Expo Go SDK 54+.

### 2. `useAuth` auto-initialize
O hook chamava `initialize()` automaticamente via `useEffect`. Com React 19 StrictMode (double-mount), isso causava duas chamadas concorrentes ao `SecureStore`, que pode travar no Expo Go.

### 3. Sem timeout
Se `SecureStore.getItemAsync()` não respondesse, `isLoading` ficava `true` para sempre.

## Fixes

| Arquivo | Fix |
|---------|-----|
| `useAuth.ts` | Removido `useEffect` que chamava `initialize()` automaticamente |
| `AppNavigator.tsx` | Import direto (não barrel). `initialize()` com timeout de 5s |
| `useNotifications.ts` | `setNotificationHandler()` movido para dentro do `useEffect` |
| `LoginScreen.tsx` | Import direto de `useAuth` |
| `RegisterScreen.tsx` | Import direto de `useAuth` |

## Test plan

- [ ] `git pull origin develop && cd mobile`
- [ ] `rm -rf node_modules && npm install --legacy-peer-deps`
- [ ] `expo start --clear`
- [ ] App deve mostrar a tela de login em até 5 segundos