### PR TITLE
feat(mobile): implement real httpClient with axios

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/native-stack": "^7.14.7",
     "axios": "^1.13.6",
     "expo": "~54.0.33",
+    "expo-constants": "~18.0.13",
     "expo-location": "~19.0.8",
     "expo-notifications": "~0.32.16",
     "expo-secure-store": "~15.0.8",

--- a/mobile/src/infrastructure/http/axios-http-client.ts
+++ b/mobile/src/infrastructure/http/axios-http-client.ts
@@ -1,0 +1,97 @@
+import axios, { AxiosInstance, AxiosError } from 'axios';
+import { HttpClient, RequestConfig, HttpError, AuthenticationError } from './http-client';
+import type { AuthTokenService } from './auth-token.service';
+import { API_BASE_URL } from './config';
+
+export class AxiosHttpClient implements HttpClient {
+  private client: AxiosInstance;
+  private tokenService: AuthTokenService | null = null;
+
+  constructor() {
+    this.client = axios.create({
+      baseURL: API_BASE_URL,
+      timeout: 15000,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    this.client.interceptors.request.use(async (config) => {
+      if (this.tokenService) {
+        const token = await this.tokenService.getAccessToken();
+        if (token) {
+          config.headers.Authorization = `Bearer ${token}`;
+        }
+      }
+      return config;
+    });
+  }
+
+  setTokenService(tokenService: AuthTokenService): void {
+    this.tokenService = tokenService;
+  }
+
+  async get<T>(url: string, config?: RequestConfig): Promise<T> {
+    try {
+      const response = await this.client.get<T>(url, {
+        headers: config?.headers,
+        params: config?.params,
+      });
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async post<T>(url: string, body: unknown, config?: RequestConfig): Promise<T> {
+    try {
+      const response = await this.client.post<T>(url, body, {
+        headers: config?.headers,
+        params: config?.params,
+      });
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async put<T>(url: string, body: unknown, config?: RequestConfig): Promise<T> {
+    try {
+      const response = await this.client.put<T>(url, body, {
+        headers: config?.headers,
+        params: config?.params,
+      });
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  async delete<T>(url: string, config?: RequestConfig): Promise<T> {
+    try {
+      const response = await this.client.delete<T>(url, {
+        headers: config?.headers,
+        params: config?.params,
+      });
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  private handleError(error: unknown): HttpError {
+    if (error instanceof AxiosError && error.response) {
+      const status = error.response.status;
+      const message = error.response.data?.message || error.message;
+
+      if (status === 401) {
+        return new AuthenticationError(message);
+      }
+      return new HttpError(status, message);
+    }
+
+    if (error instanceof AxiosError && error.code === 'ERR_NETWORK') {
+      return new HttpError(0, 'Network error — check if the backend is running');
+    }
+
+    return new HttpError(500, error instanceof Error ? error.message : 'Unknown error');
+  }
+}

--- a/mobile/src/infrastructure/http/config.ts
+++ b/mobile/src/infrastructure/http/config.ts
@@ -1,0 +1,16 @@
+import Constants from 'expo-constants';
+
+function getApiBaseUrl(): string {
+  // In development, use the same host as the Metro bundler (your Mac's IP)
+  if (__DEV__) {
+    const debuggerHost = Constants.expoConfig?.hostUri ?? Constants.manifest2?.extra?.expoGo?.debuggerHost;
+    const host = debuggerHost?.split(':')[0];
+    if (host) {
+      return `http://${host}:3000`;
+    }
+  }
+  // Fallback / production
+  return 'http://localhost:3000';
+}
+
+export const API_BASE_URL = getApiBaseUrl();

--- a/mobile/src/infrastructure/http/index.ts
+++ b/mobile/src/infrastructure/http/index.ts
@@ -1,14 +1,11 @@
-import type { HttpClient } from './http-client';
-
 export type { HttpClient, RequestConfig } from './http-client';
 export { HttpError, AuthenticationError } from './http-client';
 export type { AuthTokenService } from './auth-token.service';
 export { SecureAuthTokenService } from './secure-auth-token.service';
+export { API_BASE_URL } from './config';
 
-// Mock httpClient for now - will be replaced by actual implementation in feat/issue-95
-export const httpClient = {
-  get: async <T>(): Promise<T> => null as unknown as T,
-  post: async <T>(): Promise<T> => null as unknown as T,
-  put: async <T>(): Promise<T> => null as unknown as T,
-  delete: async <T>(): Promise<T> => null as unknown as T,
-} as HttpClient;
+import { AxiosHttpClient } from './axios-http-client';
+
+const axiosClient = new AxiosHttpClient();
+export const httpClient = axiosClient;
+export { axiosClient };

--- a/mobile/src/presentation/store/auth.store.ts
+++ b/mobile/src/presentation/store/auth.store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { Parent } from '@domain/entities';
 import { authService } from '@infrastructure/http/auth.service';
-import { SecureAuthTokenService, type AuthTokenService } from '@infrastructure/http';
+import { SecureAuthTokenService, type AuthTokenService, axiosClient } from '@infrastructure/http';
 import { parentRepository } from '@data/repositories';
 
 interface AuthStoreState {
@@ -21,6 +21,7 @@ let tokenService: AuthTokenService;
 const getTokenService = (): AuthTokenService => {
   if (!tokenService) {
     tokenService = new SecureAuthTokenService();
+    axiosClient.setTokenService(tokenService);
   }
   return tokenService;
 };


### PR DESCRIPTION
## Summary

- Replace mock httpClient (returned null for everything) with real axios implementation
- Auto-detects backend URL from Metro bundler host (same machine IP, port 3000)
- Auth token injected automatically via axios interceptor
- Proper error mapping to `HttpError` / `AuthenticationError`

## Files

| File | Change |
|------|--------|
| `config.ts` | API base URL detection from Expo Constants |
| `axios-http-client.ts` | Full `HttpClient` implementation with axios |
| `index.ts` | Export real client instead of mock |
| `auth.store.ts` | Wire token service into httpClient |
| `package.json` | Add `expo-constants` |

## Test plan

- [ ] `npm install --legacy-peer-deps`
- [ ] Start backend: `cd backend && docker-compose up -d && npm run start:dev`
- [ ] `expo start --clear`
- [ ] Register: preencher nome, email, telefone, senha → deve criar conta
- [ ] Login: usar credenciais criadas → deve autenticar

Closes #95