### PR TITLE
chore(mobile): ignore ios/ and android/ generated directories

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 .expo/
+ios/
+android/
 dist/
 build/
 coverage/


### PR DESCRIPTION
## Summary

- Add `ios/` and `android/` to `mobile/.gitignore` — these folders are generated automatically by Expo/Xcode and should not be tracked in the repository

## Test plan

- [ ] `git status` shows `mobile/ios/` as ignored after applying this change