### PR TITLE
fix(web): use accessToken from backend AuthResponseDto in loginAction

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,0 +1,20 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: './',
+})
+
+// Add any custom config to be passed to Jest
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
+  testTimeout: 10000,
+}
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+module.exports = createJestConfig(customJestConfig)

--- a/web/jest.setup.js
+++ b/web/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,5 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+function decodeJWT(token: string) {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+
+    const payload = parts[1];
+    // Add padding if needed
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const decoded = Buffer.from(padded, 'base64').toString('utf-8');
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+}
+
 export function middleware(request: NextRequest) {
   const token = request.cookies.get('onmyway_token')?.value;
 
@@ -13,6 +30,11 @@ export function middleware(request: NextRequest) {
   // Public paths: redirect to dashboard if already authenticated
   if (request.nextUrl.pathname === '/login') {
     if (token) {
+      const payload = decodeJWT(token);
+      const schoolId = payload?.schoolId || payload?.parentId;
+      if (schoolId) {
+        return NextResponse.redirect(new URL(`/dashboard/${schoolId}/arrivals`, request.url));
+      }
       return NextResponse.redirect(new URL('/dashboard', request.url));
     }
   }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,16 +14,27 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20.0.0",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "autoprefixer": "^10.4.0",
         "eslint": "^8.0.0",
         "eslint-config-next": "^14.0.0",
+        "jest-environment-jsdom": "^30.3.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^3.3.0",
         "typescript": "^5.0.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -36,6 +47,170 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -199,6 +374,114 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-mock": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@sinonjs/fake-timers": "^15.0.0",
+        "@types/node": "*",
+        "jest-message-util": "30.3.0",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -486,6 +769,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
+      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -502,6 +812,107 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -511,6 +922,53 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/json5": {
@@ -557,6 +1015,37 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
@@ -1156,6 +1645,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1759,6 +2258,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1829,6 +2344,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -1840,6 +2362,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -1855,6 +2391,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -1928,6 +2478,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1980,6 +2537,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2006,6 +2574,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2041,6 +2617,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -3273,6 +3862,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3308,6 +3951,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3634,6 +4287,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3830,6 +4490,154 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.3.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.3.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-mock": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3857,6 +4665,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -4015,6 +4863,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4067,6 +4926,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4285,6 +5154,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4508,6 +5384,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4786,6 +5675,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4888,6 +5815,20 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5025,6 +5966,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5102,6 +6050,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5287,6 +6255,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5302,6 +6280,29 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -5545,6 +6546,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5629,6 +6643,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -5746,6 +6767,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5757,6 +6798,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5809,6 +6876,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -6024,6 +7101,67 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6247,6 +7385,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,18 +11,22 @@
     "lint:fix": "eslint --fix src/"
   },
   "dependencies": {
+    "axios": "^1.6.0",
     "next": "^14.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "axios": "^1.6.0"
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "autoprefixer": "^10.4.0",
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.0.0",
+    "jest-environment-jsdom": "^30.3.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.0.0"

--- a/web/src/app/dashboard/layout.tsx
+++ b/web/src/app/dashboard/layout.tsx
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { ReactNode } from 'react';
+
+export default async function DashboardLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('onmyway_token')?.value;
+
+  // Ensure user is authenticated before accessing dashboard
+  if (!token) {
+    redirect('/login');
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { LoginForm } from '@/components/auth/LoginForm';
+
 export default function LoginPage() {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50">
@@ -7,11 +9,7 @@ export default function LoginPage() {
         <h1 className="text-2xl font-bold text-center text-gray-900 mb-6">
           onMyWay
         </h1>
-        <h2 className="text-xl font-semibold text-center text-gray-700 mb-8">
-          Login
-        </h2>
-        {/* Login form will be implemented in following tasks */}
-        <p className="text-center text-gray-500">Login form coming soon</p>
+        <LoginForm />
       </div>
     </div>
   );

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,8 +1,19 @@
-'use client';
-
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 import { LoginForm } from '@/components/auth/LoginForm';
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('onmyway_token')?.value;
+
+  // If already authenticated, redirect to dashboard
+  if (token) {
+    // TODO: Extract schoolId from token or from session
+    // For now, redirect to a default dashboard route
+    // This will be updated once we have proper session management
+    redirect('/dashboard');
+  }
+
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50">
       <div className="w-full max-w-md p-8 bg-white rounded-lg shadow">

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { LoginForm } from '@/components/auth/LoginForm';
+import { getSchoolIdFromToken } from '@/lib/jwt';
 
 export default async function LoginPage() {
   const cookieStore = await cookies();
@@ -8,9 +9,11 @@ export default async function LoginPage() {
 
   // If already authenticated, redirect to dashboard
   if (token) {
-    // TODO: Extract schoolId from token or from session
-    // For now, redirect to a default dashboard route
-    // This will be updated once we have proper session management
+    const schoolId = getSchoolIdFromToken(token);
+    if (schoolId) {
+      redirect(`/dashboard/${schoolId}/arrivals`);
+    }
+    // Fallback if schoolId cannot be extracted (should not happen)
     redirect('/dashboard');
   }
 

--- a/web/src/components/auth/LoginForm.tsx
+++ b/web/src/components/auth/LoginForm.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useLogin } from '@/hooks/useLogin';
+
+export function LoginForm() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const { login, isLoading, error } = useLogin();
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await login(email, password);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !isLoading) {
+      const form = e.currentTarget.form;
+      if (form) {
+        form.dispatchEvent(new Event('submit', { bubbles: true }));
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          onKeyDown={handleKeyDown}
+          required
+          disabled={isLoading}
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+        />
+      </div>
+
+      <div>
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          onKeyDown={handleKeyDown}
+          required
+          disabled={isLoading}
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+        />
+      </div>
+
+      {error && <div className="text-sm text-red-600 text-center">{error}</div>}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {isLoading ? 'Entrando...' : 'Entrar'}
+      </button>
+    </form>
+  );
+}

--- a/web/src/components/auth/__tests__/LoginForm.test.tsx
+++ b/web/src/components/auth/__tests__/LoginForm.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LoginForm } from '../LoginForm';
+import { useLogin } from '@/hooks/useLogin';
+
+jest.mock('@/hooks/useLogin');
+
+describe('LoginForm', () => {
+  let mockUseLogin: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLogin = useLogin as jest.Mock;
+    mockUseLogin.mockReturnValue({
+      login: jest.fn(),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('renders email field, password field, and submit button', () => {
+    render(<LoginForm />);
+
+    const emailInput = screen.getByPlaceholderText('Email');
+    const passwordInput = screen.getByPlaceholderText('Senha');
+    const submitButton = screen.getByRole('button', { name: /Entrar/i });
+
+    expect(emailInput).toBeInTheDocument();
+    expect(passwordInput).toBeInTheDocument();
+    expect(submitButton).toBeInTheDocument();
+  });
+
+  it('shows "Entrar" button text when not loading', () => {
+    render(<LoginForm />);
+    const button = screen.getByRole('button', { name: /Entrar/i });
+    expect(button).toHaveTextContent('Entrar');
+  });
+
+  it('shows "Entrando..." button text when isLoading=true', () => {
+    mockUseLogin.mockReturnValue({
+      login: jest.fn(),
+      isLoading: true,
+      error: null,
+    });
+
+    render(<LoginForm />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Entrando...');
+  });
+
+  it('disables submit button when isLoading=true', () => {
+    mockUseLogin.mockReturnValue({
+      login: jest.fn(),
+      isLoading: true,
+      error: null,
+    });
+
+    render(<LoginForm />);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('disables input fields when isLoading=true', () => {
+    mockUseLogin.mockReturnValue({
+      login: jest.fn(),
+      isLoading: true,
+      error: null,
+    });
+
+    render(<LoginForm />);
+    const emailInput = screen.getByPlaceholderText('Email') as HTMLInputElement;
+    const passwordInput = screen.getByPlaceholderText('Senha') as HTMLInputElement;
+
+    expect(emailInput.disabled).toBe(true);
+    expect(passwordInput.disabled).toBe(true);
+  });
+
+  it('displays error message when error is set', () => {
+    mockUseLogin.mockReturnValue({
+      login: jest.fn(),
+      isLoading: false,
+      error: 'Email ou senha inválidos',
+    });
+
+    render(<LoginForm />);
+    const errorMessage = screen.getByText('Email ou senha inválidos');
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it('does not display error message when error is null', () => {
+    render(<LoginForm />);
+    expect(screen.queryByText(/Email ou senha inválidos/)).not.toBeInTheDocument();
+  });
+
+  it('calls login function with email and password when form is submitted', async () => {
+    const mockLogin = jest.fn();
+    mockUseLogin.mockReturnValue({
+      login: mockLogin,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<LoginForm />);
+
+    const emailInput = screen.getByPlaceholderText('Email');
+    const passwordInput = screen.getByPlaceholderText('Senha');
+    const submitButton = screen.getByRole('button');
+
+    await userEvent.type(emailInput, 'test@example.com');
+    await userEvent.type(passwordInput, 'password123');
+    await userEvent.click(submitButton);
+
+    expect(mockLogin).toHaveBeenCalledWith('test@example.com', 'password123');
+  });
+
+  it('triggers form submit when Enter is pressed in email field', async () => {
+    const mockLogin = jest.fn();
+    mockUseLogin.mockReturnValue({
+      login: mockLogin,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<LoginForm />);
+
+    const emailInput = screen.getByPlaceholderText('Email');
+    const passwordInput = screen.getByPlaceholderText('Senha');
+
+    await userEvent.type(emailInput, 'test@example.com');
+    await userEvent.type(passwordInput, 'password123');
+    fireEvent.keyDown(emailInput, { key: 'Enter' });
+
+    expect(mockLogin).toHaveBeenCalledWith('test@example.com', 'password123');
+  });
+
+  it('triggers form submit when Enter is pressed in password field', async () => {
+    const mockLogin = jest.fn();
+    mockUseLogin.mockReturnValue({
+      login: mockLogin,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<LoginForm />);
+
+    const emailInput = screen.getByPlaceholderText('Email');
+    const passwordInput = screen.getByPlaceholderText('Senha');
+
+    await userEvent.type(emailInput, 'test@example.com');
+    await userEvent.type(passwordInput, 'password123');
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+
+    expect(mockLogin).toHaveBeenCalledWith('test@example.com', 'password123');
+  });
+
+  it('does not submit when Enter is pressed while loading', async () => {
+    const mockLogin = jest.fn();
+    mockUseLogin.mockReturnValue({
+      login: mockLogin,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<LoginForm />);
+
+    const passwordInput = screen.getByPlaceholderText('Senha');
+    fireEvent.keyDown(passwordInput, { key: 'Enter' });
+
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('updates form field values as user types', async () => {
+    render(<LoginForm />);
+
+    const emailInput = screen.getByPlaceholderText('Email') as HTMLInputElement;
+    const passwordInput = screen.getByPlaceholderText('Senha') as HTMLInputElement;
+
+    await userEvent.type(emailInput, 'test@example.com');
+    await userEvent.type(passwordInput, 'password123');
+
+    expect(emailInput.value).toBe('test@example.com');
+    expect(passwordInput.value).toBe('password123');
+  });
+});

--- a/web/src/hooks/__tests__/useLogin.test.ts
+++ b/web/src/hooks/__tests__/useLogin.test.ts
@@ -1,0 +1,111 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { useLogin } from '../useLogin';
+import * as loginModule from '@/lib/actions/login.action';
+
+jest.mock('next/navigation');
+jest.mock('@/lib/actions/login.action');
+
+describe('useLogin', () => {
+  let mockRouter: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouter = { push: jest.fn() };
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  });
+
+  it('returns initial state with isLoading=false and error=null', () => {
+    const { result } = renderHook(() => useLogin());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.login).toBe('function');
+  });
+
+  it('sets isLoading=true while loginAction is in flight', async () => {
+    const mockLoginAction = loginModule.loginAction as jest.Mock;
+    mockLoginAction.mockImplementation(() => new Promise(resolve => {
+      // Resolve after a delay to simulate async operation
+      setTimeout(() => resolve({ success: true, schoolId: 'school-123' }), 100);
+    }));
+
+    const { result } = renderHook(() => useLogin());
+
+    act(() => {
+      result.current.login('test@example.com', 'password');
+    });
+
+    // Should be loading immediately
+    expect(result.current.isLoading).toBe(true);
+
+    // Wait for the action to complete
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('calls router.push with correct dashboard URL on success', async () => {
+    const mockLoginAction = loginModule.loginAction as jest.Mock;
+    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-456' });
+
+    const { result } = renderHook(() => useLogin());
+
+    await act(async () => {
+      await result.current.login('test@example.com', 'password');
+    });
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/dashboard/school-456/arrivals');
+  });
+
+  it('sets error message on login failure', async () => {
+    const mockLoginAction = loginModule.loginAction as jest.Mock;
+    const errorMessage = 'Email ou senha inválidos';
+    mockLoginAction.mockResolvedValue({ success: false, error: errorMessage });
+
+    const { result } = renderHook(() => useLogin());
+
+    await act(async () => {
+      await result.current.login('test@example.com', 'wrongpassword');
+    });
+
+    expect(result.current.error).toBe(errorMessage);
+    expect(result.current.isLoading).toBe(false);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it('clears previous error when login is called again', async () => {
+    const mockLoginAction = loginModule.loginAction as jest.Mock;
+
+    const { result } = renderHook(() => useLogin());
+
+    // First login fails
+    mockLoginAction.mockResolvedValue({ success: false, error: 'Error' });
+    await act(async () => {
+      await result.current.login('test@example.com', 'wrongpassword');
+    });
+    expect(result.current.error).toBe('Error');
+
+    // Second login attempt clears error during submission
+    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-123' });
+    await act(async () => {
+      await result.current.login('test@example.com', 'correctpassword');
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not set isLoading to false on success (router.push handles navigation)', async () => {
+    const mockLoginAction = loginModule.loginAction as jest.Mock;
+    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-123' });
+
+    const { result } = renderHook(() => useLogin());
+
+    await act(async () => {
+      await result.current.login('test@example.com', 'password');
+    });
+
+    // isLoading remains true because router.push redirects the page
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/web/src/hooks/__tests__/useLogin.test.ts
+++ b/web/src/hooks/__tests__/useLogin.test.ts
@@ -25,24 +25,25 @@ describe('useLogin', () => {
 
   it('sets isLoading=true while loginAction is in flight', async () => {
     const mockLoginAction = loginModule.loginAction as jest.Mock;
-    mockLoginAction.mockImplementation(() => new Promise(resolve => {
-      // Resolve after a delay to simulate async operation
-      setTimeout(() => resolve({ success: true, schoolId: 'school-123' }), 100);
-    }));
+    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-123' });
 
     const { result } = renderHook(() => useLogin());
 
+    let loginPromise: Promise<void>;
     act(() => {
-      result.current.login('test@example.com', 'password');
+      loginPromise = result.current.login('test@example.com', 'password');
     });
 
     // Should be loading immediately
     expect(result.current.isLoading).toBe(true);
 
     // Wait for the action to complete
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+    await act(async () => {
+      await loginPromise!;
     });
+
+    // After success, isLoading stays true because of router.push
+    expect(result.current.isLoading).toBe(true);
   });
 
   it('calls router.push with correct dashboard URL on success', async () => {

--- a/web/src/hooks/useLogin.ts
+++ b/web/src/hooks/useLogin.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { loginAction } from '@/lib/actions/login.action';
+
+export function useLogin(): {
+  login: (email: string, password: string) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+} {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  const login = async (email: string, password: string) => {
+    setIsLoading(true);
+    setError(null);
+
+    const result = await loginAction(email, password);
+
+    if (result.success) {
+      router.push(`/dashboard/${result.schoolId}/arrivals`);
+    } else {
+      setError(result.error);
+      setIsLoading(false);
+    }
+  };
+
+  return { login, isLoading, error };
+}

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -1,0 +1,145 @@
+import axios, { AxiosInstance } from 'axios';
+import * as authModule from '../auth';
+
+jest.mock('axios');
+jest.mock('../auth');
+
+// Helper to handle promise rejections in tests
+const handleRejection = (promise: any) => {
+  return promise.catch(() => {
+    // Silently handle rejection to avoid unhandled rejection warnings
+  });
+};
+
+describe('api', () => {
+  let mockAxiosInstance: jest.Mocked<AxiosInstance>;
+  let mockedAxios: jest.Mocked<typeof axios>;
+  let mockedAuth: jest.Mocked<typeof authModule>;
+  let requestInterceptorSuccess: any;
+  let requestInterceptorError: any;
+  let responseInterceptorSuccess: any;
+  let responseInterceptorError: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedAxios = axios as jest.Mocked<typeof axios>;
+    mockedAuth = authModule as jest.Mocked<typeof authModule>;
+
+    // Create mock instance with interceptors
+    mockAxiosInstance = {
+      interceptors: {
+        request: {
+          use: jest.fn((success, error) => {
+            requestInterceptorSuccess = success;
+            requestInterceptorError = error;
+            return 0;
+          }),
+        },
+        response: {
+          use: jest.fn((success, error) => {
+            responseInterceptorSuccess = success;
+            responseInterceptorError = error;
+            return 0;
+          }),
+        },
+      },
+    } as any;
+
+    mockedAxios.create.mockReturnValue(mockAxiosInstance);
+
+    // Delete cached module and re-require to get fresh import with current mocks
+    delete require.cache[require.resolve('../api')];
+    require('../api');
+  });
+
+  describe('axios instance creation', () => {
+    it('creates axios instance with all required config', () => {
+      const calls = mockedAxios.create.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+
+      const firstCall = calls[0][0];
+      expect(firstCall).toMatchObject({
+        baseURL: 'http://localhost:3000',
+        timeout: 10000,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+  });
+
+  describe('request interceptor', () => {
+    it('attaches Authorization header when token is present', () => {
+      mockedAuth.getToken.mockReturnValue('test-token-123');
+
+      const config = { headers: {} } as any;
+      const result = requestInterceptorSuccess(config);
+
+      expect(result.headers.Authorization).toBe('Bearer test-token-123');
+    });
+
+    it('does not add Authorization header when no token', () => {
+      mockedAuth.getToken.mockReturnValue(null);
+
+      const config = { headers: {} } as any;
+      const result = requestInterceptorSuccess(config);
+
+      expect(result.headers.Authorization).toBeUndefined();
+    });
+
+    it('preserves config properties', () => {
+      mockedAuth.getToken.mockReturnValue('token');
+
+      const config = { method: 'POST', url: '/api/test', headers: {}, data: { id: 1 } } as any;
+      const result = requestInterceptorSuccess(config);
+
+      expect(result.method).toBe('POST');
+      expect(result.url).toBe('/api/test');
+      expect(result.data).toEqual({ id: 1 });
+    });
+
+    it('rejects error in error handler', () => {
+      const testError = new Error('Network error');
+      const result = requestInterceptorError(testError);
+
+      return handleRejection(result);
+    });
+  });
+
+  describe('response interceptor', () => {
+    it('returns response on success', () => {
+      const response = { status: 200, data: { message: 'ok' } } as any;
+      const result = responseInterceptorSuccess(response);
+
+      expect(result).toBe(response);
+    });
+
+    it('clears token on 401 response', () => {
+      mockedAuth.clearToken.mockClear();
+
+      const error = { response: { status: 401 } } as any;
+      const result = responseInterceptorError(error);
+
+      expect(mockedAuth.clearToken).toHaveBeenCalled();
+      return handleRejection(result);
+    });
+
+    it('does not clear token on non-401 response', () => {
+      mockedAuth.clearToken.mockClear();
+
+      const error = { response: { status: 500 } } as any;
+      const result = responseInterceptorError(error);
+
+      expect(mockedAuth.clearToken).not.toHaveBeenCalled();
+      return handleRejection(result);
+    });
+
+    it('rejects error without response', () => {
+      const error = new Error('Network error');
+      const result = responseInterceptorError(error);
+
+      return handleRejection(result);
+    });
+  });
+});

--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,99 @@
+import { TOKEN_KEY, getToken, setToken, clearToken, isAuthenticated } from '../auth';
+
+// Mock document.cookie
+let mockCookies: { [key: string]: string } = {};
+
+Object.defineProperty(document, 'cookie', {
+  writable: true,
+  value: '',
+  configurable: true,
+});
+
+const createCookieGetter = () => {
+  return Object.entries(mockCookies)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('; ');
+};
+
+const createCookieSetter = (cookieString: string) => {
+  const [nameValue] = cookieString.split(';');
+  const [name, value] = nameValue.split('=');
+  const trimmedName = name.trim();
+  if (value === undefined || value === '' || cookieString.includes('Max-Age=0')) {
+    delete mockCookies[trimmedName];
+  } else {
+    mockCookies[trimmedName] = decodeURIComponent(value.trim());
+  }
+};
+
+Object.defineProperty(document, 'cookie', {
+  get: createCookieGetter,
+  set: createCookieSetter,
+  configurable: true,
+});
+
+describe('auth', () => {
+  beforeEach(() => {
+    mockCookies = {};
+  });
+
+  describe('getToken', () => {
+    it('returns null when no token in cookie', () => {
+      expect(getToken()).toBeNull();
+    });
+
+    it('returns the token when present in cookie', () => {
+      const testToken = 'test-jwt-token-123';
+      setToken(testToken);
+      expect(getToken()).toBe(testToken);
+    });
+
+    it('handles encoded tokens', () => {
+      const testToken = 'token+with/special=chars';
+      setToken(testToken);
+      expect(getToken()).toBe(testToken);
+    });
+  });
+
+  describe('setToken', () => {
+    it('stores token in cookie', () => {
+      const testToken = 'new-test-token';
+      setToken(testToken);
+      expect(getToken()).toBe(testToken);
+    });
+
+    it('handles special characters in token', () => {
+      const testToken = 'token+with/special=chars&more';
+      setToken(testToken);
+      expect(getToken()).toBe(testToken);
+    });
+  });
+
+  describe('clearToken', () => {
+    it('removes the token from cookie', () => {
+      const testToken = 'token-to-remove';
+      setToken(testToken);
+      expect(getToken()).toBe(testToken);
+
+      clearToken();
+      expect(getToken()).toBeNull();
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('returns true when token is present', () => {
+      setToken('test-token');
+      expect(isAuthenticated()).toBe(true);
+    });
+
+    it('returns false when no token present', () => {
+      expect(isAuthenticated()).toBe(false);
+    });
+
+    it('returns false after clearing token', () => {
+      setToken('test-token');
+      clearToken();
+      expect(isAuthenticated()).toBe(false);
+    });
+  });
+});

--- a/web/src/lib/actions/__tests__/login.action.test.ts
+++ b/web/src/lib/actions/__tests__/login.action.test.ts
@@ -25,7 +25,7 @@ describe('loginAction', () => {
     mockedAxios.post.mockResolvedValue({
       data: {
         token: 'jwt-token-123',
-        parent: { id: 'school-456' },
+        parent: { schoolId: 'school-456' },
       },
     });
 
@@ -38,7 +38,7 @@ describe('loginAction', () => {
     mockedAxios.post.mockResolvedValue({
       data: {
         token: 'jwt-token-123',
-        parent: { id: 'school-456' },
+        parent: { schoolId: 'school-456' },
       },
     });
 
@@ -48,7 +48,7 @@ describe('loginAction', () => {
       'onmyway_token',
       'jwt-token-123',
       expect.objectContaining({
-        httpOnly: false,
+        httpOnly: true,
         maxAge: 7 * 24 * 60 * 60,
         path: '/',
         sameSite: 'strict',

--- a/web/src/lib/actions/__tests__/login.action.test.ts
+++ b/web/src/lib/actions/__tests__/login.action.test.ts
@@ -24,7 +24,7 @@ describe('loginAction', () => {
   it('returns success with schoolId on successful login', async () => {
     mockedAxios.post.mockResolvedValue({
       data: {
-        token: 'jwt-token-123',
+        accessToken: 'jwt-token-123',
         parent: { schoolId: 'school-456' },
       },
     });
@@ -37,7 +37,7 @@ describe('loginAction', () => {
   it('sets onmyway_token cookie on successful login', async () => {
     mockedAxios.post.mockResolvedValue({
       data: {
-        token: 'jwt-token-123',
+        accessToken: 'jwt-token-123',
         parent: { schoolId: 'school-456' },
       },
     });
@@ -59,7 +59,7 @@ describe('loginAction', () => {
   it('posts to correct API endpoint', async () => {
     mockedAxios.post.mockResolvedValue({
       data: {
-        token: 'jwt-token-123',
+        accessToken: 'jwt-token-123',
         parent: { id: 'school-456' },
       },
     });
@@ -154,7 +154,7 @@ describe('loginAction', () => {
   it('passes correct headers and timeout to axios', async () => {
     mockedAxios.post.mockResolvedValue({
       data: {
-        token: 'jwt-token-123',
+        accessToken: 'jwt-token-123',
         parent: { id: 'school-456' },
       },
     });

--- a/web/src/lib/actions/__tests__/login.action.test.ts
+++ b/web/src/lib/actions/__tests__/login.action.test.ts
@@ -1,0 +1,175 @@
+import axios from 'axios';
+import { loginAction } from '../login.action';
+import { cookies } from 'next/headers';
+
+jest.mock('axios');
+jest.mock('next/headers');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedCookies = cookies as jest.Mock;
+
+describe('loginAction', () => {
+  let mockCookieStore: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup cookie mock
+    mockCookieStore = {
+      set: jest.fn(),
+    };
+    mockedCookies.mockResolvedValue(mockCookieStore);
+  });
+
+  it('returns success with schoolId on successful login', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        token: 'jwt-token-123',
+        parent: { id: 'school-456' },
+      },
+    });
+
+    const result = await loginAction('test@example.com', 'password123');
+
+    expect(result).toEqual({ success: true, schoolId: 'school-456' });
+  });
+
+  it('sets onmyway_token cookie on successful login', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        token: 'jwt-token-123',
+        parent: { id: 'school-456' },
+      },
+    });
+
+    await loginAction('test@example.com', 'password123');
+
+    expect(mockCookieStore.set).toHaveBeenCalledWith(
+      'onmyway_token',
+      'jwt-token-123',
+      expect.objectContaining({
+        httpOnly: false,
+        maxAge: 7 * 24 * 60 * 60,
+        path: '/',
+        sameSite: 'strict',
+      })
+    );
+  });
+
+  it('posts to correct API endpoint', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        token: 'jwt-token-123',
+        parent: { id: 'school-456' },
+      },
+    });
+
+    await loginAction('test@example.com', 'password123');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/login'),
+      { email: 'test@example.com', password: 'password123' },
+      expect.any(Object)
+    );
+  });
+
+  it('returns error message on 401 response', async () => {
+    mockedAxios.post.mockRejectedValue({
+      response: { status: 401 },
+      isAxiosError: true,
+    });
+    mockedAxios.isAxiosError = jest.fn(() => true);
+
+    const result = await loginAction('test@example.com', 'wrongpassword');
+
+    expect(result).toEqual({ success: false, error: 'Email ou senha inválidos' });
+  });
+
+  it('returns error message on 400 response with single message', async () => {
+    mockedAxios.post.mockRejectedValue({
+      response: { status: 400, data: { message: 'Invalid request' } },
+      isAxiosError: true,
+    });
+    mockedAxios.isAxiosError = jest.fn(() => true);
+
+    const result = await loginAction('test@example.com', 'password');
+
+    expect(result).toEqual({ success: false, error: 'Invalid request' });
+  });
+
+  it('returns error message on 400 response with array of messages', async () => {
+    mockedAxios.post.mockRejectedValue({
+      response: {
+        status: 400,
+        data: { message: ['Error 1', 'Error 2'] },
+      },
+      isAxiosError: true,
+    });
+    mockedAxios.isAxiosError = jest.fn(() => true);
+
+    const result = await loginAction('test@example.com', 'password');
+
+    expect(result).toEqual({ success: false, error: 'Error 1, Error 2' });
+  });
+
+  it('returns generic error message on 400 response without message', async () => {
+    mockedAxios.post.mockRejectedValue({
+      response: { status: 400, data: {} },
+      isAxiosError: true,
+    });
+    mockedAxios.isAxiosError = jest.fn(() => true);
+
+    const result = await loginAction('test@example.com', 'password');
+
+    expect(result).toEqual({ success: false, error: 'Email ou senha inválidos' });
+  });
+
+  it('returns generic error message on network error', async () => {
+    mockedAxios.post.mockRejectedValue(new Error('Network error'));
+    mockedAxios.isAxiosError = jest.fn(() => false);
+
+    const result = await loginAction('test@example.com', 'password');
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Erro ao fazer login. Tente novamente.',
+    });
+  });
+
+  it('returns generic error message on server error (5xx)', async () => {
+    mockedAxios.post.mockRejectedValue({
+      response: { status: 500 },
+      isAxiosError: true,
+    });
+    mockedAxios.isAxiosError = jest.fn(() => true);
+
+    const result = await loginAction('test@example.com', 'password');
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Erro ao fazer login. Tente novamente.',
+    });
+  });
+
+  it('passes correct headers and timeout to axios', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        token: 'jwt-token-123',
+        parent: { id: 'school-456' },
+      },
+    });
+
+    await loginAction('test@example.com', 'password123');
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      {
+        timeout: 10000,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  });
+});

--- a/web/src/lib/actions/login.action.ts
+++ b/web/src/lib/actions/login.action.ts
@@ -21,11 +21,11 @@ export async function loginAction(
       },
     );
 
-    const { token, parent } = response.data;
+    const { accessToken, parent } = response.data;
 
     // Set the cookie on the server
     const cookieStore = await cookies();
-    cookieStore.set('onmyway_token', token, {
+    cookieStore.set('onmyway_token', accessToken, {
       httpOnly: true,
       maxAge: 7 * 24 * 60 * 60, // 7 days
       path: '/',

--- a/web/src/lib/actions/login.action.ts
+++ b/web/src/lib/actions/login.action.ts
@@ -26,14 +26,14 @@ export async function loginAction(
     // Set the cookie on the server
     const cookieStore = await cookies();
     cookieStore.set('onmyway_token', token, {
-      httpOnly: false,
+      httpOnly: true,
       maxAge: 7 * 24 * 60 * 60, // 7 days
       path: '/',
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'strict',
     });
 
-    return { success: true, schoolId: parent.id };
+    return { success: true, schoolId: parent.schoolId };
   } catch (error) {
     // Handle different error scenarios
     if (axios.isAxiosError(error)) {

--- a/web/src/lib/actions/login.action.ts
+++ b/web/src/lib/actions/login.action.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import axios from 'axios';
+
+const baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+export async function loginAction(
+  email: string,
+  password: string,
+): Promise<{ success: true; schoolId: string } | { success: false; error: string }> {
+  try {
+    const response = await axios.post(
+      `${baseURL}/auth/login`,
+      { email, password },
+      {
+        timeout: 10000,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    const { token, parent } = response.data;
+
+    // Set the cookie on the server
+    const cookieStore = await cookies();
+    cookieStore.set('onmyway_token', token, {
+      httpOnly: false,
+      maxAge: 7 * 24 * 60 * 60, // 7 days
+      path: '/',
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+    });
+
+    return { success: true, schoolId: parent.id };
+  } catch (error) {
+    // Handle different error scenarios
+    if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        return { success: false, error: 'Email ou senha inválidos' };
+      }
+      if (error.response?.status === 400) {
+        const messages = error.response.data?.message;
+        const message = Array.isArray(messages)
+          ? messages.join(', ')
+          : messages || 'Email ou senha inválidos';
+        return { success: false, error: message };
+      }
+    }
+    return { success: false, error: 'Erro ao fazer login. Tente novamente.' };
+  }
+}

--- a/web/src/lib/jwt.ts
+++ b/web/src/lib/jwt.ts
@@ -1,0 +1,35 @@
+export interface JWTPayload {
+  parentId?: string;
+  schoolId?: string;
+  [key: string]: any;
+}
+
+/**
+ * Decode JWT token and extract payload
+ * JWT format: header.payload.signature
+ */
+export function decodeJWT(token: string): JWTPayload | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+
+    const payload = parts[1];
+    // Add padding if needed
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const decoded = Buffer.from(padded, 'base64').toString('utf-8');
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+}
+
+export function getSchoolIdFromToken(token: string): string | null {
+  const payload = decodeJWT(token);
+  if (!payload) {
+    return null;
+  }
+  // Try both schoolId and parentId
+  return payload.schoolId || payload.parentId || null;
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,9 +1,11 @@
 export interface AuthResponse {
-  token: string;
+  accessToken: string;
+  refreshToken: string;
   parent: {
     id: string;
     name: string;
     email: string;
+    schoolId: string;
   };
 }
 

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -23,6 +23,10 @@
     "noEmit": true,
     "incremental": true,
     "isolatedModules": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary

- `loginAction` was reading `response.data.token` but the backend `AuthResponseDto` returns `accessToken` and `refreshToken`
- Cookie `onmyway_token` was being stored as `"undefined"`, breaking all authenticated requests
- Updated `AuthResponse` in `types/index.ts` to match the backend contract (`accessToken`, `refreshToken`, `parent.schoolId`)
- Updated login action tests to reflect the correct field names

## Test plan

- [x] `npm run lint` passes (0 warnings)
- [x] `npm run build` passes
- [x] All 46 tests pass (`npx jest`)

Closes #180