### PR TITLE
feat(web): API client types and server-side fetch helpers

### DIFF
--- a/web/src/lib/__tests__/server-api.test.ts
+++ b/web/src/lib/__tests__/server-api.test.ts
@@ -1,0 +1,133 @@
+import {
+  listSchools,
+  getSchool,
+  getSchoolArrivals,
+  getSchoolStats,
+} from '../server-api';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function mockOkResponse(data: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(data),
+  } as Response);
+}
+
+function mockErrorResponse(status: number, statusText: string) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.resolve({}),
+  } as Response);
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('listSchools', () => {
+  it('returns list of schools', async () => {
+    const schools = [
+      { id: 'school-1', name: 'School A', location: { lat: -23.5, lng: -46.6 } },
+    ];
+    mockFetch.mockReturnValueOnce(mockOkResponse(schools));
+
+    const result = await listSchools();
+
+    expect(result).toEqual(schools);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/schools'),
+      expect.objectContaining({ headers: expect.objectContaining({ 'Content-Type': 'application/json' }) }),
+    );
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetch.mockReturnValueOnce(mockErrorResponse(500, 'Internal Server Error'));
+
+    await expect(listSchools()).rejects.toThrow('API error: 500 Internal Server Error');
+  });
+});
+
+describe('getSchool', () => {
+  it('returns a single school by id', async () => {
+    const school = { id: 'school-1', name: 'School A', location: { lat: -23.5, lng: -46.6 } };
+    mockFetch.mockReturnValueOnce(mockOkResponse(school));
+
+    const result = await getSchool('school-1');
+
+    expect(result).toEqual(school);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/schools/school-1'),
+      expect.any(Object),
+    );
+  });
+
+  it('throws on 404', async () => {
+    mockFetch.mockReturnValueOnce(mockErrorResponse(404, 'Not Found'));
+
+    await expect(getSchool('missing-id')).rejects.toThrow('API error: 404 Not Found');
+  });
+});
+
+describe('getSchoolArrivals', () => {
+  it('returns arrivals with Authorization header', async () => {
+    const arrivals = [
+      { parentId: 'p-1', distanceMeters: 300, durationMinutes: 4, routePolyline: 'abc' },
+    ];
+    mockFetch.mockReturnValueOnce(mockOkResponse(arrivals));
+
+    const result = await getSchoolArrivals('school-1', 'my-token');
+
+    expect(result).toEqual(arrivals);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/schools/school-1/arrivals'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer my-token' }),
+      }),
+    );
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetch.mockReturnValueOnce(mockErrorResponse(401, 'Unauthorized'));
+
+    await expect(getSchoolArrivals('school-1', 'bad-token')).rejects.toThrow(
+      'API error: 401 Unauthorized',
+    );
+  });
+});
+
+describe('getSchoolStats', () => {
+  it('returns school stats with Authorization header', async () => {
+    const stats = {
+      totalParents: 10,
+      avgETA: 8,
+      etaLessThan5Min: 3,
+      eta5To15Min: 5,
+      etaGreaterThan15Min: 2,
+    };
+    mockFetch.mockReturnValueOnce(mockOkResponse(stats));
+
+    const result = await getSchoolStats('school-1', 'my-token');
+
+    expect(result).toEqual(stats);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/schools/school-1/stats'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer my-token' }),
+      }),
+    );
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetch.mockReturnValueOnce(mockErrorResponse(403, 'Forbidden'));
+
+    await expect(getSchoolStats('school-1', 'bad-token')).rejects.toThrow(
+      'API error: 403 Forbidden',
+    );
+  });
+});

--- a/web/src/lib/__tests__/server-api.test.ts
+++ b/web/src/lib/__tests__/server-api.test.ts
@@ -46,10 +46,33 @@ describe('listSchools', () => {
     );
   });
 
+  it('returns empty array when no schools exist', async () => {
+    mockFetch.mockReturnValueOnce(mockOkResponse([]));
+
+    const result = await listSchools();
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not send Authorization header', async () => {
+    mockFetch.mockReturnValueOnce(mockOkResponse([]));
+
+    await listSchools();
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers).not.toHaveProperty('Authorization');
+  });
+
   it('throws on HTTP error', async () => {
     mockFetch.mockReturnValueOnce(mockErrorResponse(500, 'Internal Server Error'));
 
     await expect(listSchools()).rejects.toThrow('API error: 500 Internal Server Error');
+  });
+
+  it('propagates network errors (fetch rejects)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    await expect(listSchools()).rejects.toThrow('Network failure');
   });
 });
 
@@ -67,10 +90,26 @@ describe('getSchool', () => {
     );
   });
 
+  it('does not send Authorization header', async () => {
+    const school = { id: 'school-1', name: 'School A', location: { lat: -23.5, lng: -46.6 } };
+    mockFetch.mockReturnValueOnce(mockOkResponse(school));
+
+    await getSchool('school-1');
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers).not.toHaveProperty('Authorization');
+  });
+
   it('throws on 404', async () => {
     mockFetch.mockReturnValueOnce(mockErrorResponse(404, 'Not Found'));
 
     await expect(getSchool('missing-id')).rejects.toThrow('API error: 404 Not Found');
+  });
+
+  it('propagates network errors (fetch rejects)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    await expect(getSchool('school-1')).rejects.toThrow('Network failure');
   });
 });
 
@@ -98,6 +137,20 @@ describe('getSchoolArrivals', () => {
     await expect(getSchoolArrivals('school-1', 'bad-token')).rejects.toThrow(
       'API error: 401 Unauthorized',
     );
+  });
+
+  it('returns empty array when no arrivals exist', async () => {
+    mockFetch.mockReturnValueOnce(mockOkResponse([]));
+
+    const result = await getSchoolArrivals('school-1', 'my-token');
+
+    expect(result).toEqual([]);
+  });
+
+  it('propagates network errors (fetch rejects)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    await expect(getSchoolArrivals('school-1', 'my-token')).rejects.toThrow('Network failure');
   });
 });
 
@@ -129,5 +182,11 @@ describe('getSchoolStats', () => {
     await expect(getSchoolStats('school-1', 'bad-token')).rejects.toThrow(
       'API error: 403 Forbidden',
     );
+  });
+
+  it('propagates network errors (fetch rejects)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    await expect(getSchoolStats('school-1', 'my-token')).rejects.toThrow('Network failure');
   });
 });

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,0 +1,46 @@
+import { Arrival, School, SchoolStats } from '@/types';
+
+const baseURL = process.env.API_URL || 'http://localhost:3000';
+
+async function serverFetch<T>(
+  path: string,
+  token?: string,
+): Promise<T> {
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${baseURL}${path}`, { headers });
+
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export async function listSchools(): Promise<School[]> {
+  return serverFetch<School[]>('/schools');
+}
+
+export async function getSchool(schoolId: string): Promise<School> {
+  return serverFetch<School>(`/schools/${schoolId}`);
+}
+
+export async function getSchoolArrivals(
+  schoolId: string,
+  token: string,
+): Promise<Arrival[]> {
+  return serverFetch<Arrival[]>(`/schools/${schoolId}/arrivals`, token);
+}
+
+export async function getSchoolStats(
+  schoolId: string,
+  token: string,
+): Promise<SchoolStats> {
+  return serverFetch<SchoolStats>(`/schools/${schoolId}/stats`, token);
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -5,25 +5,34 @@ export interface AuthResponse {
     id: string;
     name: string;
     email: string;
+    phone: string;
     schoolId: string;
+    createdAt: string;
   };
 }
 
-export interface ETA {
+export interface SchoolLocation {
+  lat: number;
+  lng: number;
+}
+
+export interface School {
+  id: string;
+  name: string;
+  location: SchoolLocation;
+}
+
+export interface Arrival {
   parentId: string;
   distanceMeters: number;
   durationMinutes: number;
   routePolyline: string;
 }
 
-export interface Arrival {
-  parentId: string;
-  parentName: string;
-  eta: ETA;
-}
-
 export interface SchoolStats {
   totalParents: number;
-  arrivingCount: number;
   avgETA: number;
+  etaLessThan5Min: number;
+  eta5To15Min: number;
+  etaGreaterThan15Min: number;
 }


### PR DESCRIPTION
## Summary

- Replace placeholder types in `web/src/types/index.ts` with backend-accurate types (`School`, `Arrival`, `SchoolStats`, `AuthResponse`)
- Add `web/src/lib/server-api.ts` with server-side `fetch`-based helpers for schools and arrivals endpoints (no client-side Axios)
- Add unit tests in `web/src/lib/__tests__/server-api.test.ts` covering happy path and error cases for all helpers

## Test plan

- [x] `npm run lint` — PASS (0 warnings)
- [x] `npm run build` — PASS
- [x] `npm test` — PASS (66 tests, 7 suites)

Closes #185