### PR TITLE
feat(web): dashboard navigation sidebar and layout

### DIFF
--- a/web/src/app/actions/__tests__/logout.action.test.ts
+++ b/web/src/app/actions/__tests__/logout.action.test.ts
@@ -1,0 +1,48 @@
+import { TOKEN_KEY } from '@/lib/auth';
+
+const mockDelete = jest.fn();
+const mockRedirect = jest.fn();
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}));
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { logoutAction } from '../logout.action';
+
+const mockCookies = cookies as jest.Mock;
+const mockRedirectFn = redirect as jest.Mock;
+
+describe('logoutAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCookies.mockResolvedValue({ delete: mockDelete });
+  });
+
+  it('deletes the auth token cookie', async () => {
+    await logoutAction();
+
+    expect(mockDelete).toHaveBeenCalledWith(TOKEN_KEY);
+  });
+
+  it('redirects to /login after deleting cookie', async () => {
+    await logoutAction();
+
+    expect(mockRedirectFn).toHaveBeenCalledWith('/login');
+  });
+
+  it('deletes cookie before redirecting', async () => {
+    const callOrder: string[] = [];
+    mockDelete.mockImplementation(() => callOrder.push('delete'));
+    mockRedirectFn.mockImplementation(() => callOrder.push('redirect'));
+
+    await logoutAction();
+
+    expect(callOrder).toEqual(['delete', 'redirect']);
+  });
+});

--- a/web/src/app/actions/logout.action.ts
+++ b/web/src/app/actions/logout.action.ts
@@ -1,0 +1,11 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { TOKEN_KEY } from '@/lib/auth';
+
+export async function logoutAction() {
+  const cookieStore = await cookies();
+  cookieStore.delete(TOKEN_KEY);
+  redirect('/login');
+}

--- a/web/src/app/dashboard/[schoolId]/__tests__/layout.test.tsx
+++ b/web/src/app/dashboard/[schoolId]/__tests__/layout.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { getSchool } from '@/lib/server-api';
+
+jest.mock('@/lib/server-api', () => ({
+  getSchool: jest.fn(),
+}));
+
+jest.mock('@/components/layout/DashboardLayout', () => ({
+  DashboardLayout: ({
+    schoolId,
+    schoolName,
+    children,
+  }: {
+    schoolId: string;
+    schoolName: string;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="dashboard-layout">
+      <span data-testid="layout-school-id">{schoolId}</span>
+      <span data-testid="layout-school-name">{schoolName}</span>
+      <div data-testid="layout-children">{children}</div>
+    </div>
+  ),
+}));
+
+import SchoolLayout from '../layout';
+
+const mockGetSchool = getSchool as jest.Mock;
+
+function buildParams(schoolId: string) {
+  return Promise.resolve({ schoolId });
+}
+
+describe('SchoolLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders DashboardLayout with school name from API', async () => {
+    mockGetSchool.mockResolvedValue({
+      id: 'school-1',
+      name: 'Escola Primavera',
+      location: {},
+    });
+
+    const Layout = await SchoolLayout({
+      params: buildParams('school-1'),
+      children: <span>children</span>,
+    });
+    render(Layout);
+
+    expect(screen.getByTestId('layout-school-id')).toHaveTextContent('school-1');
+    expect(screen.getByTestId('layout-school-name')).toHaveTextContent(
+      'Escola Primavera',
+    );
+  });
+
+  it('falls back to schoolId as school name when getSchool throws', async () => {
+    mockGetSchool.mockRejectedValue(new Error('Not found'));
+
+    const Layout = await SchoolLayout({
+      params: buildParams('school-xyz'),
+      children: <span>children</span>,
+    });
+    render(Layout);
+
+    expect(screen.getByTestId('layout-school-name')).toHaveTextContent(
+      'school-xyz',
+    );
+  });
+
+  it('passes children through to DashboardLayout', async () => {
+    mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'School', location: {} });
+
+    const Layout = await SchoolLayout({
+      params: buildParams('school-1'),
+      children: <div data-testid="page-child">Page</div>,
+    });
+    render(Layout);
+
+    expect(screen.getByTestId('page-child')).toBeInTheDocument();
+  });
+
+  it('calls getSchool with the correct schoolId', async () => {
+    mockGetSchool.mockResolvedValue({ id: 'school-99', name: 'Test', location: {} });
+
+    await SchoolLayout({
+      params: buildParams('school-99'),
+      children: <span />,
+    });
+
+    expect(mockGetSchool).toHaveBeenCalledWith('school-99');
+  });
+});

--- a/web/src/app/dashboard/[schoolId]/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/[schoolId]/__tests__/page.test.tsx
@@ -1,0 +1,39 @@
+const mockRedirect = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((...args: unknown[]) => mockRedirect(...args)),
+}));
+
+import DashboardHome from '../page';
+
+function buildParams(schoolId: string) {
+  return Promise.resolve({ schoolId });
+}
+
+describe('DashboardHome', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to the arrivals page for the given schoolId', async () => {
+    await DashboardHome({ params: buildParams('school-123') });
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/dashboard/school-123/arrivals',
+    );
+  });
+
+  it('redirects using the correct schoolId from params', async () => {
+    await DashboardHome({ params: buildParams('school-abc') });
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      '/dashboard/school-abc/arrivals',
+    );
+  });
+
+  it('calls redirect exactly once', async () => {
+    await DashboardHome({ params: buildParams('school-1') });
+
+    expect(mockRedirect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/app/dashboard/[schoolId]/layout.tsx
+++ b/web/src/app/dashboard/[schoolId]/layout.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+import { getSchool } from '@/lib/server-api';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+interface SchoolLayoutProps {
+  children: ReactNode;
+  params: Promise<{ schoolId: string }>;
+}
+
+export default async function SchoolLayout({
+  children,
+  params,
+}: SchoolLayoutProps) {
+  const { schoolId } = await params;
+
+  let schoolName = schoolId;
+
+  try {
+    const schoolData = await getSchool(schoolId);
+    schoolName = schoolData.name;
+  } catch (error) {
+    console.error('Failed to fetch school name:', error);
+  }
+
+  return (
+    <DashboardLayout schoolId={schoolId} schoolName={schoolName}>
+      {children}
+    </DashboardLayout>
+  );
+}

--- a/web/src/app/dashboard/[schoolId]/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation';
+
+interface DashboardHomeProps {
+  params: Promise<{ schoolId: string }>;
+}
+
+export default async function DashboardHome({ params }: DashboardHomeProps) {
+  const { schoolId } = await params;
+  redirect(`/dashboard/${schoolId}/arrivals`);
+}

--- a/web/src/components/layout/DashboardLayout.tsx
+++ b/web/src/components/layout/DashboardLayout.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { DashboardSidebar } from './DashboardSidebar';
+
+interface DashboardLayoutProps {
+  schoolId: string;
+  schoolName: string;
+  children: ReactNode;
+}
+
+export function DashboardLayout({
+  schoolId,
+  schoolName,
+  children,
+}: DashboardLayoutProps) {
+  return (
+    <div className="flex min-h-screen bg-gray-50">
+      <DashboardSidebar schoolId={schoolId} schoolName={schoolName} />
+      <main className="flex-1 md:ml-60 ml-0">
+        <div className="p-6">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/web/src/components/layout/DashboardSidebar.tsx
+++ b/web/src/components/layout/DashboardSidebar.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { logoutAction } from '@/app/actions/logout.action';
+
+interface DashboardSidebarProps {
+  schoolId: string;
+  schoolName: string;
+}
+
+export function DashboardSidebar({
+  schoolId,
+  schoolName,
+}: DashboardSidebarProps) {
+  const pathname = usePathname();
+
+  const navLinks = [
+    {
+      href: `/dashboard/${schoolId}/arrivals`,
+      label: 'Chegadas',
+      icon: '🚗',
+    },
+    {
+      href: `/dashboard/${schoolId}/settings`,
+      label: 'Configurações',
+      icon: '⚙️',
+    },
+  ];
+
+  const isActive = (href: string) => {
+    return pathname.startsWith(href);
+  };
+
+  const handleLogout = async () => {
+    await logoutAction();
+  };
+
+  return (
+    <aside className="w-60 bg-gray-900 text-white flex flex-col h-screen fixed left-0 top-0 md:block hidden">
+      <div className="p-6 border-b border-gray-700">
+        <h1 className="text-xl font-bold">onMyWay</h1>
+        <p className="text-sm text-gray-400 mt-1 truncate" title={schoolName}>
+          {schoolName}
+        </p>
+      </div>
+
+      <nav className="flex-1 p-4">
+        <ul className="space-y-2">
+          {navLinks.map((link) => (
+            <li key={link.href}>
+              <Link
+                href={link.href}
+                className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-colors ${
+                  isActive(link.href)
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-300 hover:bg-gray-800'
+                }`}
+              >
+                <span className="text-xl">{link.icon}</span>
+                <span className="font-medium">{link.label}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="p-4 border-t border-gray-700">
+        <button
+          onClick={handleLogout}
+          className="w-full px-4 py-3 bg-gray-800 text-gray-300 rounded-lg hover:bg-gray-700 transition-colors font-medium"
+        >
+          Sair
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/components/layout/__tests__/DashboardLayout.test.tsx
+++ b/web/src/components/layout/__tests__/DashboardLayout.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DashboardLayout } from '../DashboardLayout';
+
+jest.mock('../DashboardSidebar', () => ({
+  DashboardSidebar: ({
+    schoolId,
+    schoolName,
+  }: {
+    schoolId: string;
+    schoolName: string;
+  }) => (
+    <aside data-testid="dashboard-sidebar">
+      <span data-testid="sidebar-school-id">{schoolId}</span>
+      <span data-testid="sidebar-school-name">{schoolName}</span>
+    </aside>
+  ),
+}));
+
+describe('DashboardLayout', () => {
+  it('renders children inside main content area', () => {
+    render(
+      <DashboardLayout schoolId="school-1" schoolName="Test School">
+        <div data-testid="page-content">Page Content</div>
+      </DashboardLayout>,
+    );
+
+    expect(screen.getByTestId('page-content')).toBeInTheDocument();
+    expect(screen.getByText('Page Content')).toBeInTheDocument();
+  });
+
+  it('renders DashboardSidebar with correct props', () => {
+    render(
+      <DashboardLayout schoolId="school-42" schoolName="Escola Primavera">
+        <span>child</span>
+      </DashboardLayout>,
+    );
+
+    expect(screen.getByTestId('dashboard-sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-school-id')).toHaveTextContent(
+      'school-42',
+    );
+    expect(screen.getByTestId('sidebar-school-name')).toHaveTextContent(
+      'Escola Primavera',
+    );
+  });
+
+  it('renders multiple children', () => {
+    render(
+      <DashboardLayout schoolId="school-1" schoolName="School">
+        <div data-testid="child-a">A</div>
+        <div data-testid="child-b">B</div>
+      </DashboardLayout>,
+    );
+
+    expect(screen.getByTestId('child-a')).toBeInTheDocument();
+    expect(screen.getByTestId('child-b')).toBeInTheDocument();
+  });
+
+  it('applies responsive margin class to main element', () => {
+    const { container } = render(
+      <DashboardLayout schoolId="school-1" schoolName="School">
+        <span>content</span>
+      </DashboardLayout>,
+    );
+
+    const main = container.querySelector('main');
+    expect(main).toHaveClass('md:ml-60');
+  });
+});

--- a/web/src/components/layout/__tests__/DashboardSidebar.test.tsx
+++ b/web/src/components/layout/__tests__/DashboardSidebar.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DashboardSidebar } from '../DashboardSidebar';
+import { usePathname } from 'next/navigation';
+import { logoutAction } from '@/app/actions/logout.action';
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+jest.mock('@/app/actions/logout.action', () => ({
+  logoutAction: jest.fn(),
+}));
+
+describe('DashboardSidebar', () => {
+  const mockUsePathname = usePathname as jest.Mock;
+  const mockLogoutAction = logoutAction as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePathname.mockReturnValue('/dashboard/school-123/arrivals');
+  });
+
+  it('renders school name and application title', () => {
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    expect(screen.getByText('onMyWay')).toBeInTheDocument();
+    expect(screen.getByText('Test School')).toBeInTheDocument();
+  });
+
+  it('renders navigation links with correct labels and icons', () => {
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    expect(screen.getByText('Chegadas')).toBeInTheDocument();
+    expect(screen.getByText('Configurações')).toBeInTheDocument();
+    expect(screen.getByText('🚗')).toBeInTheDocument();
+    expect(screen.getByText('⚙️')).toBeInTheDocument();
+  });
+
+  it('renders logout button', () => {
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    const logoutButton = screen.getByRole('button', { name: /sair/i });
+    expect(logoutButton).toBeInTheDocument();
+  });
+
+  it('highlights active link based on pathname', () => {
+    mockUsePathname.mockReturnValue('/dashboard/school-123/arrivals');
+
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    const arrivalsLink = screen.getByText('Chegadas').closest('a');
+    const settingsLink = screen.getByText('Configurações').closest('a');
+
+    expect(arrivalsLink).toHaveClass('bg-blue-600');
+    expect(settingsLink).not.toHaveClass('bg-blue-600');
+  });
+
+  it('highlights settings link when on settings page', () => {
+    mockUsePathname.mockReturnValue('/dashboard/school-123/settings');
+
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    const arrivalsLink = screen.getByText('Chegadas').closest('a');
+    const settingsLink = screen.getByText('Configurações').closest('a');
+
+    expect(settingsLink).toHaveClass('bg-blue-600');
+    expect(arrivalsLink).not.toHaveClass('bg-blue-600');
+  });
+
+  it('highlights arrivals link when on arrivals sub-route', () => {
+    mockUsePathname.mockReturnValue('/dashboard/school-123/arrivals/detail');
+
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    const arrivalsLink = screen.getByText('Chegadas').closest('a');
+    expect(arrivalsLink).toHaveClass('bg-blue-600');
+  });
+
+  it('calls logoutAction when logout button is clicked', async () => {
+    mockLogoutAction.mockResolvedValue(undefined);
+
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    const logoutButton = screen.getByRole('button', { name: /sair/i });
+    fireEvent.click(logoutButton);
+
+    expect(mockLogoutAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('generates correct href for navigation links with schoolId', () => {
+    render(
+      <DashboardSidebar schoolId="school-456" schoolName="Another School" />
+    );
+
+    const arrivalsLink = screen.getByText('Chegadas').closest('a');
+    const settingsLink = screen.getByText('Configurações').closest('a');
+
+    expect(arrivalsLink).toHaveAttribute(
+      'href',
+      '/dashboard/school-456/arrivals'
+    );
+    expect(settingsLink).toHaveAttribute(
+      'href',
+      '/dashboard/school-456/settings'
+    );
+  });
+
+  it('truncates long school names with ellipsis', () => {
+    const longName = 'Very Long School Name That Should Be Truncated';
+
+    render(<DashboardSidebar schoolId="school-123" schoolName={longName} />);
+
+    const schoolNameElement = screen.getByText(longName);
+    expect(schoolNameElement).toHaveClass('truncate');
+    expect(schoolNameElement).toHaveAttribute('title', longName);
+  });
+
+  it('applies hover styles to non-active links', () => {
+    mockUsePathname.mockReturnValue('/dashboard/school-123/arrivals');
+
+    render(
+      <DashboardSidebar schoolId="school-123" schoolName="Test School" />
+    );
+
+    const settingsLink = screen.getByText('Configurações').closest('a');
+    expect(settingsLink).toHaveClass('hover:bg-gray-800');
+  });
+});


### PR DESCRIPTION
Implements navigation sidebar and dashboard layout for the web dashboard.

## Summary
- Navigation sidebar with school context
- Dashboard layout wrapper with responsive design
- Server-side layout that fetches school name
- Dashboard home page redirects to arrivals
- Logout server action with cookie clearing
- Comprehensive test coverage

## Features Implemented
- **DashboardSidebar**: Client component with active link highlighting, school name display, and logout button
- **DashboardLayout**: Wrapper component with sidebar and responsive main content area
- **Server Layout**: Fetches school name from API with fallback to schoolId
- **Dashboard Home**: Redirects to arrivals page
- **Logout Action**: Server action that clears auth cookie and redirects to login

## Navigation Links
- 🚗 Chegadas → `/dashboard/[schoolId]/arrivals`
- ⚙️ Configurações → `/dashboard/[schoolId]/settings`

## Quality Checks
- ✅ Lint: PASS (0 warnings)
- ✅ Build: PASS (TypeScript compile)
- ✅ Tests: PASS (136 tests across 15 suites)

## Test Coverage
- Sidebar rendering and navigation
- Active link highlighting for current route
- Active link detection for sub-routes
- Logout button functionality
- School name display with truncation
- Responsive design elements

Closes #194