### PR TITLE
feat(web): school settings page

### DIFF
--- a/web/src/app/actions/__tests__/update-school-config.action.test.ts
+++ b/web/src/app/actions/__tests__/update-school-config.action.test.ts
@@ -1,0 +1,57 @@
+const mockGet = jest.fn();
+const mockUpdateSchoolConfig = jest.fn();
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+jest.mock('@/lib/server-api', () => ({
+  updateSchoolConfig: jest.fn(),
+}));
+
+import { cookies } from 'next/headers';
+import { updateSchoolConfig } from '@/lib/server-api';
+import { updateSchoolConfigAction } from '../update-school-config.action';
+
+const mockCookies = cookies as jest.Mock;
+const mockUpdateSchoolConfigFn = updateSchoolConfig as jest.Mock;
+
+const config = { geofenceRadiusMeters: 500, notificationThresholdMeters: 300 };
+
+describe('updateSchoolConfigAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCookies.mockResolvedValue({ get: mockGet });
+  });
+
+  it('returns success with data when token is present', async () => {
+    mockGet.mockReturnValue({ value: 'valid-token' });
+    mockUpdateSchoolConfigFn.mockResolvedValue(config);
+
+    const result = await updateSchoolConfigAction('school-1', config);
+
+    expect(result).toEqual({ success: true, data: config });
+    expect(mockUpdateSchoolConfigFn).toHaveBeenCalledWith('school-1', config, 'valid-token');
+  });
+
+  it('returns error when no token in cookies', async () => {
+    mockGet.mockReturnValue(undefined);
+
+    const result = await updateSchoolConfigAction('school-1', config);
+
+    expect(result).toEqual({ success: false, error: 'Não autenticado' });
+    expect(mockUpdateSchoolConfigFn).not.toHaveBeenCalled();
+  });
+
+  it('returns error when API call throws', async () => {
+    mockGet.mockReturnValue({ value: 'valid-token' });
+    mockUpdateSchoolConfigFn.mockRejectedValue(new Error('Server error'));
+
+    const result = await updateSchoolConfigAction('school-1', config);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Erro ao atualizar configurações. Tente novamente.',
+    });
+  });
+});

--- a/web/src/app/actions/update-school-config.action.ts
+++ b/web/src/app/actions/update-school-config.action.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { TOKEN_KEY } from '@/lib/auth';
+import { updateSchoolConfig } from '@/lib/server-api';
+import { SchoolConfig } from '@/types';
+
+export async function updateSchoolConfigAction(
+  schoolId: string,
+  config: SchoolConfig,
+): Promise<{ success: boolean; error?: string; data?: SchoolConfig }> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get(TOKEN_KEY)?.value;
+
+    if (!token) {
+      return { success: false, error: 'Não autenticado' };
+    }
+
+    const updatedConfig = await updateSchoolConfig(schoolId, config, token);
+    return { success: true, data: updatedConfig };
+  } catch (error) {
+    console.error('Error updating school config:', error);
+    return {
+      success: false,
+      error: 'Erro ao atualizar configurações. Tente novamente.',
+    };
+  }
+}

--- a/web/src/app/dashboard/[schoolId]/settings/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/settings/page.tsx
@@ -1,0 +1,32 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { TOKEN_KEY } from '@/lib/auth';
+import { SchoolSettingsForm } from '@/components/settings/SchoolSettingsForm';
+
+interface SettingsPageProps {
+  params: Promise<{ schoolId: string }>;
+}
+
+export default async function SettingsPage({ params }: SettingsPageProps) {
+  const { schoolId } = await params;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_KEY)?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="p-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Configurações da Escola</h1>
+        <p className="text-gray-600 mt-2">
+          Configure as preferências de geolocalização e notificações
+        </p>
+      </div>
+
+      <SchoolSettingsForm schoolId={schoolId} />
+    </div>
+  );
+}

--- a/web/src/components/settings/SchoolSettingsForm.tsx
+++ b/web/src/components/settings/SchoolSettingsForm.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { updateSchoolConfigAction } from '@/app/actions/update-school-config.action';
+
+interface SchoolSettingsFormProps {
+  schoolId: string;
+}
+
+export function SchoolSettingsForm({ schoolId }: SchoolSettingsFormProps) {
+  const [geofenceRadiusMeters, setGeofenceRadiusMeters] = useState<string>('500');
+  const [notificationThresholdMeters, setNotificationThresholdMeters] = useState<string>('300');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const validateInputs = (): boolean => {
+    const geofence = Number(geofenceRadiusMeters);
+    const notification = Number(notificationThresholdMeters);
+
+    if (isNaN(geofence) || geofence < 100 || geofence > 5000) {
+      setValidationError('Raio do geofence deve estar entre 100 e 5000 metros');
+      return false;
+    }
+
+    if (isNaN(notification) || notification < 100 || notification > 2000) {
+      setValidationError('Distância de notificação deve estar entre 100 e 2000 metros');
+      return false;
+    }
+
+    setValidationError(null);
+    return true;
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+
+    if (!validateInputs()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    const result = await updateSchoolConfigAction(schoolId, {
+      geofenceRadiusMeters: Number(geofenceRadiusMeters),
+      notificationThresholdMeters: Number(notificationThresholdMeters),
+    });
+
+    setIsLoading(false);
+
+    if (result.success) {
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+    } else {
+      setError(result.error || 'Erro ao atualizar configurações');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-6 max-w-lg">
+      <div>
+        <label htmlFor="geofenceRadius" className="block text-sm font-medium text-gray-700 mb-2">
+          Raio do Geofence (metros)
+        </label>
+        <input
+          id="geofenceRadius"
+          type="number"
+          min="100"
+          max="5000"
+          step="1"
+          value={geofenceRadiusMeters}
+          onChange={(e) => setGeofenceRadiusMeters(e.target.value)}
+          disabled={isLoading}
+          required
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+        />
+        <p className="mt-1 text-xs text-gray-500">Intervalo: 100-5000 metros</p>
+      </div>
+
+      <div>
+        <label htmlFor="notificationThreshold" className="block text-sm font-medium text-gray-700 mb-2">
+          Distância para Notificação (metros)
+        </label>
+        <input
+          id="notificationThreshold"
+          type="number"
+          min="100"
+          max="2000"
+          step="1"
+          value={notificationThresholdMeters}
+          onChange={(e) => setNotificationThresholdMeters(e.target.value)}
+          disabled={isLoading}
+          required
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+        />
+        <p className="mt-1 text-xs text-gray-500">Intervalo: 100-2000 metros</p>
+      </div>
+
+      {validationError && (
+        <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          {validationError}
+        </div>
+      )}
+
+      {error && (
+        <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="text-sm text-green-600 bg-green-50 border border-green-200 rounded-lg px-4 py-3">
+          Configurações atualizadas com sucesso!
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+      >
+        {isLoading ? 'Salvando...' : 'Salvar Configurações'}
+      </button>
+    </form>
+  );
+}

--- a/web/src/components/settings/__tests__/SchoolSettingsForm.test.tsx
+++ b/web/src/components/settings/__tests__/SchoolSettingsForm.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SchoolSettingsForm } from '../SchoolSettingsForm';
+import { updateSchoolConfigAction } from '@/app/actions/update-school-config.action';
+
+jest.mock('@/app/actions/update-school-config.action', () => ({
+  updateSchoolConfigAction: jest.fn(),
+}));
+
+describe('SchoolSettingsForm', () => {
+  const mockUpdateSchoolConfigAction = updateSchoolConfigAction as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders form with default values', () => {
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const geofenceInput = screen.getByLabelText(/raio do geofence/i);
+    const notificationInput = screen.getByLabelText(/distância para notificação/i);
+
+    expect(geofenceInput).toHaveValue(500);
+    expect(notificationInput).toHaveValue(300);
+  });
+
+  it('renders submit button', () => {
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+    expect(submitButton).toBeInTheDocument();
+  });
+
+  it('shows validation error for geofence radius below minimum', async () => {
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const geofenceInput = screen.getByLabelText(/raio do geofence/i);
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+
+    fireEvent.change(geofenceInput, { target: { value: '50' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/raio do geofence deve estar entre 100 e 5000 metros/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockUpdateSchoolConfigAction).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error for geofence radius above maximum', async () => {
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const geofenceInput = screen.getByLabelText(/raio do geofence/i);
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+
+    fireEvent.change(geofenceInput, { target: { value: '6000' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/raio do geofence deve estar entre 100 e 5000 metros/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockUpdateSchoolConfigAction).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error for notification threshold below minimum', async () => {
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const notificationInput = screen.getByLabelText(/distância para notificação/i);
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+
+    fireEvent.change(notificationInput, { target: { value: '50' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/distância de notificação deve estar entre 100 e 2000 metros/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockUpdateSchoolConfigAction).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error for notification threshold above maximum', async () => {
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const notificationInput = screen.getByLabelText(/distância para notificação/i);
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+
+    fireEvent.change(notificationInput, { target: { value: '2500' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/distância de notificação deve estar entre 100 e 2000 metros/i)
+      ).toBeInTheDocument();
+    });
+
+    expect(mockUpdateSchoolConfigAction).not.toHaveBeenCalled();
+  });
+
+  it('submits form with valid values', async () => {
+    mockUpdateSchoolConfigAction.mockResolvedValue({
+      success: true,
+      data: {
+        geofenceRadiusMeters: 1000,
+        notificationThresholdMeters: 500,
+      },
+    });
+
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const geofenceInput = screen.getByLabelText(/raio do geofence/i);
+    const notificationInput = screen.getByLabelText(/distância para notificação/i);
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+
+    fireEvent.change(geofenceInput, { target: { value: '1000' } });
+    fireEvent.change(notificationInput, { target: { value: '500' } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockUpdateSchoolConfigAction).toHaveBeenCalledWith('school-123', {
+        geofenceRadiusMeters: 1000,
+        notificationThresholdMeters: 500,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/configurações atualizadas com sucesso!/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on submission failure', async () => {
+    mockUpdateSchoolConfigAction.mockResolvedValue({
+      success: false,
+      error: 'Erro no servidor',
+    });
+
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/erro no servidor/i)).toBeInTheDocument();
+    });
+  });
+
+  it('disables inputs and button during submission', async () => {
+    mockUpdateSchoolConfigAction.mockImplementation(
+      () =>
+        new Promise((resolve) => setTimeout(() => resolve({ success: true }), 100))
+    );
+
+    render(<SchoolSettingsForm schoolId="school-123" />);
+
+    const geofenceInput = screen.getByLabelText(/raio do geofence/i);
+    const notificationInput = screen.getByLabelText(/distância para notificação/i);
+    const submitButton = screen.getByRole('button', {
+      name: /salvar configurações/i,
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(geofenceInput).toBeDisabled();
+      expect(notificationInput).toBeDisabled();
+      expect(submitButton).toBeDisabled();
+      expect(screen.getByText(/salvando.../i)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/lib/__tests__/server-api.test.ts
+++ b/web/src/lib/__tests__/server-api.test.ts
@@ -3,6 +3,7 @@ import {
   getSchool,
   getSchoolArrivals,
   getSchoolStats,
+  updateSchoolConfig,
 } from '../server-api';
 
 const mockFetch = jest.fn();
@@ -188,5 +189,41 @@ describe('getSchoolStats', () => {
     mockFetch.mockRejectedValueOnce(new Error('Network failure'));
 
     await expect(getSchoolStats('school-1', 'my-token')).rejects.toThrow('Network failure');
+  });
+});
+
+describe('updateSchoolConfig', () => {
+  const config = { geofenceRadiusMeters: 500, notificationThresholdMeters: 300 };
+
+  it('sends POST to /schools/:id/config with Authorization header and body', async () => {
+    mockFetch.mockReturnValueOnce(mockOkResponse(config));
+
+    const result = await updateSchoolConfig('school-1', config, 'my-token');
+
+    expect(result).toEqual(config);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/schools/school-1/config'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(config),
+        headers: expect.objectContaining({ Authorization: 'Bearer my-token' }),
+      }),
+    );
+  });
+
+  it('throws on HTTP error', async () => {
+    mockFetch.mockReturnValueOnce(mockErrorResponse(401, 'Unauthorized'));
+
+    await expect(updateSchoolConfig('school-1', config, 'bad-token')).rejects.toThrow(
+      'API error: 401 Unauthorized',
+    );
+  });
+
+  it('propagates network errors (fetch rejects)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    await expect(updateSchoolConfig('school-1', config, 'my-token')).rejects.toThrow(
+      'Network failure',
+    );
   });
 });

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,12 +1,13 @@
-import { Arrival, School, SchoolStats } from '@/types';
+import { Arrival, School, SchoolStats, SchoolConfig } from '@/types';
 
 const baseURL = process.env.API_URL || 'http://localhost:3000';
 
 async function serverFetch<T>(
   path: string,
   token?: string,
+  options?: RequestInit,
 ): Promise<T> {
-  const headers: HeadersInit = {
+  const headers: Record<string, string> = {
     'Content-Type': 'application/json',
   };
 
@@ -14,7 +15,13 @@ async function serverFetch<T>(
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const response = await fetch(`${baseURL}${path}`, { headers });
+  const response = await fetch(`${baseURL}${path}`, {
+    ...options,
+    headers: {
+      ...headers,
+      ...options?.headers,
+    },
+  });
 
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);
@@ -43,4 +50,15 @@ export async function getSchoolStats(
   token: string,
 ): Promise<SchoolStats> {
   return serverFetch<SchoolStats>(`/schools/${schoolId}/stats`, token);
+}
+
+export async function updateSchoolConfig(
+  schoolId: string,
+  config: SchoolConfig,
+  token: string,
+): Promise<SchoolConfig> {
+  return serverFetch<SchoolConfig>(`/schools/${schoolId}/config`, token, {
+    method: 'POST',
+    body: JSON.stringify(config),
+  });
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -36,3 +36,8 @@ export interface SchoolStats {
   eta5To15Min: number;
   etaGreaterThan15Min: number;
 }
+
+export interface SchoolConfig {
+  geofenceRadiusMeters: number;
+  notificationThresholdMeters: number;
+}


### PR DESCRIPTION
## Summary

Implements school settings page for configuring geolocation and notification preferences.

- Form with geofence radius and notification threshold inputs
- Client-side validation (100-5000m for geofence, 100-2000m for notification)
- Server action for POST /schools/:id/config
- Success/error feedback with inline messages
- Comprehensive unit tests (8 test cases)

## Test plan

- [x] `npm run lint` passes (0 warnings)
- [x] `npm run build` passes
- [x] `npm test` passes (159 tests)
- [x] Form renders with default values (500m, 300m)
- [x] Validation errors show for out-of-range inputs
- [x] Submit disabled during loading state
- [x] Success message displays on save

Closes #196