### PR TITLE
feat(web): display real stats from backend in arrivals page

### DIFF
--- a/web/src/app/dashboard/[schoolId]/arrivals/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/[schoolId]/arrivals/__tests__/page.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ArrivalsPage from '../page';
-import { getSchoolArrivals, getSchool } from '@/lib/server-api';
+import { getSchoolArrivals, getSchool, getSchoolStats } from '@/lib/server-api';
 import { TOKEN_KEY } from '@/lib/auth';
 
 // Mock next/headers
@@ -13,6 +13,7 @@ jest.mock('next/headers', () => ({
 jest.mock('@/lib/server-api', () => ({
   getSchoolArrivals: jest.fn(),
   getSchool: jest.fn(),
+  getSchoolStats: jest.fn(),
 }));
 
 // Mock ArrivalsContainer to isolate page behaviour
@@ -22,15 +23,18 @@ jest.mock('@/components/arrivals/ArrivalsContainer', () => ({
     schoolId,
     schoolName,
     initialArrivals,
+    stats,
   }: {
     schoolId: string;
     schoolName: string;
     initialArrivals: unknown[];
+    stats: unknown;
   }) => (
     <div data-testid="arrivals-container">
       <span data-testid="school-id">{schoolId}</span>
       <span data-testid="school-name">{schoolName}</span>
       <span data-testid="arrivals-count">{initialArrivals.length}</span>
+      <span data-testid="stats-exists">{stats !== null ? 'yes' : 'no'}</span>
     </div>
   ),
 }));
@@ -40,11 +44,20 @@ import { cookies } from 'next/headers';
 const mockCookies = cookies as jest.Mock;
 const mockGetSchoolArrivals = getSchoolArrivals as jest.Mock;
 const mockGetSchool = getSchool as jest.Mock;
+const mockGetSchoolStats = getSchoolStats as jest.Mock;
 
 const sampleArrivals = [
   { parentId: 'p-1', distanceMeters: 300, durationMinutes: 4, routePolyline: '' },
   { parentId: 'p-2', distanceMeters: 500, durationMinutes: 7, routePolyline: '' },
 ];
+
+const sampleStats = {
+  totalParents: 2,
+  avgETA: 5,
+  etaLessThan5Min: 1,
+  eta5To15Min: 1,
+  etaGreaterThan15Min: 0,
+};
 
 function buildParams(schoolId: string) {
   return Promise.resolve({ schoolId });
@@ -61,6 +74,7 @@ describe('ArrivalsPage', () => {
     });
     mockGetSchoolArrivals.mockResolvedValue(sampleArrivals);
     mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'Escola Primavera', location: {} });
+    mockGetSchoolStats.mockResolvedValue(sampleStats);
 
     const Page = await ArrivalsPage({ params: buildParams('school-1') });
     render(Page);
@@ -68,6 +82,7 @@ describe('ArrivalsPage', () => {
     expect(screen.getByTestId('school-id')).toHaveTextContent('school-1');
     expect(screen.getByTestId('school-name')).toHaveTextContent('Escola Primavera');
     expect(screen.getByTestId('arrivals-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('stats-exists')).toHaveTextContent('yes');
   });
 
   it('falls back to schoolId as schoolName when getSchool throws', async () => {
@@ -76,6 +91,7 @@ describe('ArrivalsPage', () => {
     });
     mockGetSchoolArrivals.mockResolvedValue([]);
     mockGetSchool.mockRejectedValue(new Error('Not found'));
+    mockGetSchoolStats.mockResolvedValue(sampleStats);
 
     const Page = await ArrivalsPage({ params: buildParams('school-42') });
     render(Page);
@@ -92,7 +108,9 @@ describe('ArrivalsPage', () => {
     render(Page);
 
     expect(screen.getByTestId('arrivals-count')).toHaveTextContent('0');
+    expect(screen.getByTestId('stats-exists')).toHaveTextContent('no');
     expect(mockGetSchoolArrivals).not.toHaveBeenCalled();
+    expect(mockGetSchoolStats).not.toHaveBeenCalled();
   });
 
   it('renders with empty arrivals when getSchoolArrivals throws', async () => {
@@ -101,6 +119,7 @@ describe('ArrivalsPage', () => {
     });
     mockGetSchoolArrivals.mockRejectedValue(new Error('Unauthorized'));
     mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'Escola Primavera', location: {} });
+    mockGetSchoolStats.mockResolvedValue(sampleStats);
 
     const Page = await ArrivalsPage({ params: buildParams('school-1') });
     render(Page);
@@ -117,6 +136,7 @@ describe('ArrivalsPage', () => {
     render(Page);
 
     expect(screen.getByTestId('school-id')).toHaveTextContent('school-xyz');
+    expect(screen.getByTestId('stats-exists')).toHaveTextContent('no');
   });
 
   it('calls getSchoolArrivals with correct schoolId and token', async () => {
@@ -125,9 +145,38 @@ describe('ArrivalsPage', () => {
     });
     mockGetSchoolArrivals.mockResolvedValue([]);
     mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'Escola', location: {} });
+    mockGetSchoolStats.mockResolvedValue(sampleStats);
 
     await ArrivalsPage({ params: buildParams('school-1') });
 
     expect(mockGetSchoolArrivals).toHaveBeenCalledWith('school-1', 'my-token');
+  });
+
+  it('calls getSchoolStats with correct schoolId and token', async () => {
+    mockCookies.mockResolvedValue({
+      get: (key: string) => (key === TOKEN_KEY ? { value: 'my-token' } : undefined),
+    });
+    mockGetSchoolArrivals.mockResolvedValue([]);
+    mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'Escola', location: {} });
+    mockGetSchoolStats.mockResolvedValue(sampleStats);
+
+    await ArrivalsPage({ params: buildParams('school-1') });
+
+    expect(mockGetSchoolStats).toHaveBeenCalledWith('school-1', 'my-token');
+  });
+
+  it('renders with null stats when getSchoolStats throws', async () => {
+    mockCookies.mockResolvedValue({
+      get: (key: string) => (key === TOKEN_KEY ? { value: 'valid-token' } : undefined),
+    });
+    mockGetSchoolArrivals.mockResolvedValue(sampleArrivals);
+    mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'Escola Primavera', location: {} });
+    mockGetSchoolStats.mockRejectedValue(new Error('Stats service unavailable'));
+
+    const Page = await ArrivalsPage({ params: buildParams('school-1') });
+    render(Page);
+
+    expect(screen.getByTestId('stats-exists')).toHaveTextContent('no');
+    expect(screen.getByTestId('arrivals-count')).toHaveTextContent('2');
   });
 });

--- a/web/src/app/dashboard/[schoolId]/arrivals/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/arrivals/page.tsx
@@ -1,8 +1,8 @@
 import { cookies } from 'next/headers';
-import { getSchoolArrivals, getSchool } from '@/lib/server-api';
+import { getSchoolArrivals, getSchool, getSchoolStats } from '@/lib/server-api';
 import { TOKEN_KEY } from '@/lib/auth';
 import ArrivalsContainer from '@/components/arrivals/ArrivalsContainer';
-import { Arrival } from '@/types';
+import { Arrival, SchoolStats } from '@/types';
 
 interface ArrivalsPageProps {
   params: Promise<{ schoolId: string }>;
@@ -13,19 +13,22 @@ export default async function ArrivalsPage({ params }: ArrivalsPageProps) {
 
   let arrivals: Arrival[] = [];
   let schoolName = schoolId;
+  let stats: SchoolStats | null = null;
 
   try {
     const cookieStore = await cookies();
     const token = cookieStore.get(TOKEN_KEY)?.value;
 
     if (token) {
-      const [arrivalsData, schoolData] = await Promise.all([
+      const [arrivalsData, schoolData, statsData] = await Promise.all([
         getSchoolArrivals(schoolId, token),
         getSchool(schoolId).catch(() => null),
+        getSchoolStats(schoolId, token).catch(() => null),
       ]);
 
       arrivals = arrivalsData;
       schoolName = schoolData?.name ?? schoolId;
+      stats = statsData;
     }
   } catch (error) {
     console.error('Error loading arrivals:', error);
@@ -36,6 +39,7 @@ export default async function ArrivalsPage({ params }: ArrivalsPageProps) {
       schoolId={schoolId}
       schoolName={schoolName}
       initialArrivals={arrivals}
+      stats={stats}
     />
   );
 }

--- a/web/src/components/arrivals/ArrivalsContainer.tsx
+++ b/web/src/components/arrivals/ArrivalsContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Arrival } from '@/types';
+import { Arrival, SchoolStats } from '@/types';
 import { useArrivals } from '@/hooks/useArrivals';
 import ConnectionHeader from './ConnectionHeader';
 import ArrivalsStats from './ArrivalsStats';
@@ -10,12 +10,14 @@ interface ArrivalsContainerProps {
   schoolId: string;
   schoolName: string;
   initialArrivals: Arrival[];
+  stats: SchoolStats | null;
 }
 
 export default function ArrivalsContainer({
   schoolId,
   schoolName,
   initialArrivals,
+  stats,
 }: ArrivalsContainerProps) {
   const { arrivals, isConnected, lastUpdatedAt } = useArrivals(
     schoolId,
@@ -28,7 +30,7 @@ export default function ArrivalsContainer({
 
       <ConnectionHeader isConnected={isConnected} lastUpdatedAt={lastUpdatedAt} />
 
-      <ArrivalsStats arrivals={arrivals} />
+      <ArrivalsStats stats={stats} />
 
       <ArrivalsQueue arrivals={arrivals} />
     </div>

--- a/web/src/components/arrivals/ArrivalsStats.tsx
+++ b/web/src/components/arrivals/ArrivalsStats.tsx
@@ -1,32 +1,36 @@
-import { Arrival } from '@/types';
+import { SchoolStats } from '@/types';
 
 interface ArrivalsStatsProps {
-  arrivals: Arrival[];
+  stats: SchoolStats | null;
 }
 
-export default function ArrivalsStats({ arrivals }: ArrivalsStatsProps) {
-  const totalArrivals = arrivals.length;
-  const avgDuration =
-    totalArrivals > 0
-      ? Math.round(
-          arrivals.reduce((sum, a) => sum + a.durationMinutes, 0) /
-            totalArrivals,
-        )
-      : 0;
-  const closestArrival =
-    arrivals.length > 0
-      ? Math.min(...arrivals.map((a) => a.durationMinutes))
-      : 0;
+export default function ArrivalsStats({ stats }: ArrivalsStatsProps) {
+  if (stats === null) {
+    return (
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+        {[...Array(4)].map((_, i) => (
+          <div
+            key={i}
+            className="bg-white rounded-lg shadow p-4 border border-gray-200 animate-pulse"
+          >
+            <div className="h-4 bg-gray-200 rounded w-24 mb-2"></div>
+            <div className="h-8 bg-gray-200 rounded w-16"></div>
+          </div>
+        ))}
+      </div>
+    );
+  }
 
-  const stats = [
-    { label: 'Total a caminho', value: totalArrivals },
-    { label: 'Tempo médio', value: `${avgDuration} min` },
-    { label: 'Próxima chegada', value: closestArrival > 0 ? `${closestArrival} min` : '—' },
+  const statCards = [
+    { label: 'Pais a caminho', value: stats.totalParents },
+    { label: 'Tempo médio', value: `${stats.avgETA} min` },
+    { label: 'menos de 5 min', value: stats.etaLessThan5Min },
+    { label: '5 a 15 min', value: stats.eta5To15Min },
   ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-      {stats.map((stat) => (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+      {statCards.map((stat) => (
         <div
           key={stat.label}
           className="bg-white rounded-lg shadow p-4 border border-gray-200"

--- a/web/src/components/arrivals/__tests__/ArrivalsContainer.test.tsx
+++ b/web/src/components/arrivals/__tests__/ArrivalsContainer.test.tsx
@@ -208,6 +208,32 @@ describe('ArrivalsContainer', () => {
     expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
   });
 
+  it('shows stats skeleton when stats prop is null', () => {
+    const { container } = render(
+      <ArrivalsContainer
+        schoolId="school-1"
+        schoolName="Escola Primavera"
+        initialArrivals={[]}
+        stats={null}
+      />,
+    );
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons).toHaveLength(4);
+  });
+
+  it('renders stat cards when stats prop is provided', () => {
+    render(
+      <ArrivalsContainer
+        schoolId="school-1"
+        schoolName="Escola Primavera"
+        initialArrivals={[]}
+        stats={sampleStats}
+      />,
+    );
+    expect(screen.getByText('Pais a caminho')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
   it('renders one list item per arrival', () => {
     const threeArrivals: Arrival[] = [
       { parentId: 'p-1', distanceMeters: 100, durationMinutes: 2, routePolyline: '' },

--- a/web/src/components/arrivals/__tests__/ArrivalsContainer.test.tsx
+++ b/web/src/components/arrivals/__tests__/ArrivalsContainer.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ArrivalsContainer from '../ArrivalsContainer';
 import { useArrivals } from '@/hooks/useArrivals';
-import { Arrival } from '@/types';
+import { Arrival, SchoolStats } from '@/types';
 
 jest.mock('@/hooks/useArrivals');
 
@@ -12,6 +12,14 @@ const sampleArrivals: Arrival[] = [
   { parentId: 'parent-1', distanceMeters: 500, durationMinutes: 10, routePolyline: '' },
   { parentId: 'parent-2', distanceMeters: 200, durationMinutes: 3, routePolyline: '' },
 ];
+
+const sampleStats: SchoolStats = {
+  totalParents: 2,
+  avgETA: 6,
+  etaLessThan5Min: 1,
+  eta5To15Min: 1,
+  etaGreaterThan15Min: 0,
+};
 
 describe('ArrivalsContainer', () => {
   beforeEach(() => {
@@ -29,6 +37,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={[]}
+        stats={null}
       />,
     );
 
@@ -41,6 +50,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={[]}
+        stats={null}
       />,
     );
 
@@ -61,6 +71,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={sampleArrivals}
+        stats={sampleStats}
       />,
     );
 
@@ -80,6 +91,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={sampleArrivals}
+        stats={sampleStats}
       />,
     );
 
@@ -99,6 +111,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={[]}
+        stats={null}
       />,
     );
 
@@ -117,6 +130,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={[]}
+        stats={null}
       />,
     );
 
@@ -135,6 +149,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={[]}
+        stats={null}
       />,
     );
 
@@ -154,6 +169,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={[]}
+        stats={null}
       />,
     );
 
@@ -166,6 +182,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-42"
         schoolName="Escola Teste"
         initialArrivals={sampleArrivals}
+        stats={null}
       />,
     );
 
@@ -184,6 +201,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={[]}
+        stats={null}
       />,
     );
 
@@ -207,6 +225,7 @@ describe('ArrivalsContainer', () => {
         schoolId="school-1"
         schoolName="Escola Primavera"
         initialArrivals={threeArrivals}
+        stats={null}
       />,
     );
 

--- a/web/src/components/arrivals/__tests__/ArrivalsStats.test.tsx
+++ b/web/src/components/arrivals/__tests__/ArrivalsStats.test.tsx
@@ -89,4 +89,37 @@ describe('ArrivalsStats', () => {
     expect(gridDiv).toHaveClass('grid-cols-2');
     expect(gridDiv).toHaveClass('md:grid-cols-4');
   });
+
+  it('does not render a card for etaGreaterThan15Min', () => {
+    const stats: SchoolStats = {
+      totalParents: 5,
+      avgETA: 20,
+      etaLessThan5Min: 0,
+      eta5To15Min: 1,
+      etaGreaterThan15Min: 4,
+    };
+    render(<ArrivalsStats stats={stats} />);
+    expect(screen.queryByText('mais de 15 min')).not.toBeInTheDocument();
+    expect(screen.queryByText('4')).not.toBeInTheDocument();
+  });
+
+  it('renders exactly 4 stat cards when stats provided', () => {
+    const stats: SchoolStats = {
+      totalParents: 3,
+      avgETA: 7,
+      etaLessThan5Min: 1,
+      eta5To15Min: 2,
+      etaGreaterThan15Min: 0,
+    };
+    const { container } = render(<ArrivalsStats stats={stats} />);
+    const cards = container.querySelectorAll('.bg-white.rounded-lg');
+    expect(cards).toHaveLength(4);
+  });
+
+  it('skeleton grid uses same layout as data grid', () => {
+    const { container } = render(<ArrivalsStats stats={null} />);
+    const gridDiv = container.querySelector('.grid');
+    expect(gridDiv).toHaveClass('grid-cols-2');
+    expect(gridDiv).toHaveClass('md:grid-cols-4');
+  });
 });

--- a/web/src/components/arrivals/__tests__/ArrivalsStats.test.tsx
+++ b/web/src/components/arrivals/__tests__/ArrivalsStats.test.tsx
@@ -1,71 +1,92 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import ArrivalsStats from '../ArrivalsStats';
-import { Arrival } from '@/types';
+import { SchoolStats } from '@/types';
 
 describe('ArrivalsStats', () => {
-  it('shows zero stats when no arrivals', () => {
-    render(<ArrivalsStats arrivals={[]} />);
-    expect(screen.getByText('Total a caminho')).toBeInTheDocument();
-    expect(screen.getByText('0')).toBeInTheDocument();
-    expect(screen.getByText('0 min')).toBeInTheDocument();
-    expect(screen.getByText('—')).toBeInTheDocument();
+  it('shows skeleton placeholders when stats is null', () => {
+    const { container } = render(<ArrivalsStats stats={null} />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons).toHaveLength(4);
   });
 
-  it('calculates total arrivals correctly', () => {
-    const arrivals: Arrival[] = [
-      { parentId: 'p-1', distanceMeters: 100, durationMinutes: 5, routePolyline: '' },
-      { parentId: 'p-2', distanceMeters: 200, durationMinutes: 10, routePolyline: '' },
-      { parentId: 'p-3', distanceMeters: 300, durationMinutes: 15, routePolyline: '' },
-    ];
-    render(<ArrivalsStats arrivals={arrivals} />);
-    expect(screen.getByText('3')).toBeInTheDocument();
-  });
+  it('renders all four stat cards with backend data', () => {
+    const stats: SchoolStats = {
+      totalParents: 12,
+      avgETA: 8,
+      etaLessThan5Min: 3,
+      eta5To15Min: 7,
+      etaGreaterThan15Min: 2,
+    };
+    render(<ArrivalsStats stats={stats} />);
 
-  it('calculates average duration correctly', () => {
-    const arrivals: Arrival[] = [
-      { parentId: 'p-1', distanceMeters: 100, durationMinutes: 6, routePolyline: '' },
-      { parentId: 'p-2', distanceMeters: 200, durationMinutes: 9, routePolyline: '' },
-      { parentId: 'p-3', distanceMeters: 300, durationMinutes: 15, routePolyline: '' },
-    ];
-    render(<ArrivalsStats arrivals={arrivals} />);
-    expect(screen.getByText('10 min')).toBeInTheDocument();
-  });
-
-  it('shows closest arrival time', () => {
-    const arrivals: Arrival[] = [
-      { parentId: 'p-1', distanceMeters: 100, durationMinutes: 3, routePolyline: '' },
-      { parentId: 'p-2', distanceMeters: 200, durationMinutes: 7, routePolyline: '' },
-      { parentId: 'p-3', distanceMeters: 300, durationMinutes: 12, routePolyline: '' },
-    ];
-    render(<ArrivalsStats arrivals={arrivals} />);
-    expect(screen.getByText('3 min')).toBeInTheDocument();
-  });
-
-  it('renders all three stat cards', () => {
-    render(<ArrivalsStats arrivals={[]} />);
-    expect(screen.getByText('Total a caminho')).toBeInTheDocument();
+    expect(screen.getByText('Pais a caminho')).toBeInTheDocument();
     expect(screen.getByText('Tempo médio')).toBeInTheDocument();
-    expect(screen.getByText('Próxima chegada')).toBeInTheDocument();
+    expect(screen.getByText('menos de 5 min')).toBeInTheDocument();
+    expect(screen.getByText('5 a 15 min')).toBeInTheDocument();
   });
 
-  it('shows single arrival stats correctly', () => {
-    const arrivals: Arrival[] = [
-      { parentId: 'p-1', distanceMeters: 300, durationMinutes: 8, routePolyline: '' },
-    ];
-    render(<ArrivalsStats arrivals={arrivals} />);
-    expect(screen.getByText('1')).toBeInTheDocument();
-    // avg duration and closest arrival are both 8 min for a single arrival
-    expect(screen.getAllByText('8 min')).toHaveLength(2);
+  it('displays total parents correctly', () => {
+    const stats: SchoolStats = {
+      totalParents: 15,
+      avgETA: 10,
+      etaLessThan5Min: 4,
+      eta5To15Min: 8,
+      etaGreaterThan15Min: 3,
+    };
+    render(<ArrivalsStats stats={stats} />);
+    expect(screen.getByText('15')).toBeInTheDocument();
   });
 
-  it('rounds average duration to nearest integer', () => {
-    const arrivals: Arrival[] = [
-      { parentId: 'p-1', distanceMeters: 100, durationMinutes: 1, routePolyline: '' },
-      { parentId: 'p-2', distanceMeters: 200, durationMinutes: 2, routePolyline: '' },
-    ];
-    render(<ArrivalsStats arrivals={arrivals} />);
-    // average = 1.5 → rounds to 2
-    expect(screen.getByText('2 min')).toBeInTheDocument();
+  it('displays average ETA with min suffix', () => {
+    const stats: SchoolStats = {
+      totalParents: 10,
+      avgETA: 12,
+      etaLessThan5Min: 2,
+      eta5To15Min: 6,
+      etaGreaterThan15Min: 2,
+    };
+    render(<ArrivalsStats stats={stats} />);
+    expect(screen.getByText('12 min')).toBeInTheDocument();
+  });
+
+  it('displays ETA breakdowns correctly', () => {
+    const stats: SchoolStats = {
+      totalParents: 20,
+      avgETA: 9,
+      etaLessThan5Min: 5,
+      eta5To15Min: 12,
+      etaGreaterThan15Min: 3,
+    };
+    render(<ArrivalsStats stats={stats} />);
+    expect(screen.getByText('5')).toBeInTheDocument(); // less than 5 min
+    expect(screen.getByText('12')).toBeInTheDocument(); // 5 to 15 min
+  });
+
+  it('shows zero values when no parents', () => {
+    const stats: SchoolStats = {
+      totalParents: 0,
+      avgETA: 0,
+      etaLessThan5Min: 0,
+      eta5To15Min: 0,
+      etaGreaterThan15Min: 0,
+    };
+    render(<ArrivalsStats stats={stats} />);
+    expect(screen.getAllByText('0')).toHaveLength(3); // total, less than 5, 5 to 15
+    expect(screen.getByText('0 min')).toBeInTheDocument(); // avg ETA
+  });
+
+  it('uses grid layout with 2 columns on mobile and 4 on desktop', () => {
+    const stats: SchoolStats = {
+      totalParents: 10,
+      avgETA: 8,
+      etaLessThan5Min: 3,
+      eta5To15Min: 5,
+      etaGreaterThan15Min: 2,
+    };
+    const { container } = render(<ArrivalsStats stats={stats} />);
+    const gridDiv = container.querySelector('.grid');
+    expect(gridDiv).toHaveClass('grid-cols-2');
+    expect(gridDiv).toHaveClass('md:grid-cols-4');
   });
 });


### PR DESCRIPTION
## Summary
- Replace client-side computed stats with server-side fetched stats
- Display 4 cards with backend-calculated values (total parents, avg ETA, <5min, 5-15min)
- Show skeleton state when stats is null
- Fetch stats server-side using getSchoolStats()

## Changes
- Modified `ArrivalsStats.tsx` to accept `SchoolStats | null` prop
- Updated `ArrivalsContainer.tsx` to pass stats prop
- Modified arrivals page to fetch stats server-side
- Added 4-card grid layout (2×2 mobile, 4×1 desktop)
- Implemented skeleton placeholders for loading state
- Updated all component and page tests

## Test Plan
- ✅ `npm run lint` passes (0 warnings)
- ✅ `npm run build` passes
- ✅ `npm test` passes (167 tests)

Closes #197