### PR TITLE
fix(web): resolve API_URL to correct backend host in server actions

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,6 @@
+# Server-side API URL (used by server components and server actions)
+API_URL=http://localhost:3000
+
+# Client-side API URL (used by browser-side components)
 NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_WS_URL=ws://localhost:3000

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "description": "Next.js web dashboard for onMyWay — real-time school arrival notifications",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
     "lint": "eslint --max-warnings 0 src/",

--- a/web/src/lib/__tests__/server-api.test.ts
+++ b/web/src/lib/__tests__/server-api.test.ts
@@ -31,6 +31,42 @@ beforeEach(() => {
   mockFetch.mockReset();
 });
 
+describe('base URL resolution', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses API_URL env var when set', async () => {
+    process.env.API_URL = 'http://backend.example.com:4000';
+    mockFetch.mockReturnValueOnce(mockOkResponse([]));
+
+    await listSchools();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://backend.example.com:4000/schools',
+      expect.any(Object),
+    );
+  });
+
+  it('falls back to http://localhost:3000 when API_URL is not set', async () => {
+    delete process.env.API_URL;
+    mockFetch.mockReturnValueOnce(mockOkResponse([]));
+
+    await listSchools();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:3000/schools',
+      expect.any(Object),
+    );
+  });
+});
+
 describe('listSchools', () => {
   it('returns list of schools', async () => {
     const schools = [

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,6 +1,8 @@
 import { Arrival, School, SchoolStats, SchoolConfig } from '@/types';
 
-const baseURL = process.env.API_URL || 'http://localhost:3000';
+function getBaseURL(): string {
+  return process.env.API_URL || 'http://localhost:3000';
+}
 
 async function serverFetch<T>(
   path: string,
@@ -15,7 +17,7 @@ async function serverFetch<T>(
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const response = await fetch(`${baseURL}${path}`, {
+  const response = await fetch(`${getBaseURL()}${path}`, {
     ...options,
     headers: {
       ...headers,


### PR DESCRIPTION
## Summary

Fixes settings page silent failure where config updates weren't reaching the backend.

**Root cause**: Next.js dev server and NestJS backend both running on port 3000, causing server actions to call themselves instead of the backend.

**Solution**: 
- Changed Next.js dev port to 3001
- Made base URL resolution dynamic for testability
- Documented required env vars in `.env.example`

## Changes

- `web/src/lib/server-api.ts` — converted `baseURL` constant to `getBaseURL()` function for dynamic env var resolution
- `web/package.json` — updated dev script to `next dev -p 3001`
- `web/.env.example` — added `API_URL` documentation with clear server/client-side distinction
- `web/src/lib/__tests__/server-api.test.ts` — added unit tests for base URL resolution

## Testing

✅ `npm run lint` — passed (0 warnings)
✅ `npm run build` — passed (TypeScript compile)
✅ `npm test` — passed (199 tests)

Verified settings form now generates `POST /schools/:id/config` requests to the correct backend port.

Closes #204

Generated with [Claude Code](https://claude.com/claude-code)