### PR TITLE
feat: DELETE /locations/me endpoint to stop location sharing

### DIFF
--- a/backend/src/data/repositories/eta.repository.ts
+++ b/backend/src/data/repositories/eta.repository.ts
@@ -68,4 +68,8 @@ export class ETARepository implements IETARepository {
 
     return resultMap;
   }
+
+  async deleteByParentId(parentId: string): Promise<void> {
+    await this.repository.delete({ parentId });
+  }
 }

--- a/backend/src/domain/repositories/eta.repository.interface.ts
+++ b/backend/src/domain/repositories/eta.repository.interface.ts
@@ -7,4 +7,5 @@ export interface IETARepository {
   findLatestByParentId(parentId: string): Promise<ETA | null>;
   findBySchoolId(schoolId: string): Promise<ETA[]>;
   findLatestBulkByParentIds(parentIds: string[]): Promise<Map<string, ETA>>;
+  deleteByParentId(parentId: string): Promise<void>;
 }

--- a/backend/src/domain/use-cases/calculate-eta.use-case.spec.ts
+++ b/backend/src/domain/use-cases/calculate-eta.use-case.spec.ts
@@ -69,6 +69,7 @@ describe('CalculateETAUseCase', () => {
       findLatestByParentId: jest.fn(),
       findBySchoolId: jest.fn(),
       findLatestBulkByParentIds: jest.fn(),
+      deleteByParentId: jest.fn(),
     } as jest.Mocked<IETARepository>;
 
     locationRepositoryMock = {

--- a/backend/src/domain/use-cases/get-arrivals-queue.use-case.spec.ts
+++ b/backend/src/domain/use-cases/get-arrivals-queue.use-case.spec.ts
@@ -86,6 +86,7 @@ describe('GetArrivalsQueueUseCase', () => {
       findLatestByParentId: jest.fn(),
       findBySchoolId: jest.fn(),
       findLatestBulkByParentIds: jest.fn(),
+      deleteByParentId: jest.fn(),
     } as jest.Mocked<IETARepository>;
 
     schoolRepositoryMock = {

--- a/backend/src/domain/use-cases/stop-sharing.use-case.spec.ts
+++ b/backend/src/domain/use-cases/stop-sharing.use-case.spec.ts
@@ -1,0 +1,136 @@
+import { StopSharingUseCase } from './stop-sharing.use-case';
+import { IETARepository } from '../repositories/eta.repository.interface';
+import { ISchoolRepository } from '../repositories/school.repository.interface';
+import { GetSchoolArrivalsUseCase } from './get-school-arrivals.use-case';
+import { ArrivalsGateway } from '../../infrastructure/websocket/arrivals.gateway';
+import { School } from '../entities/school.entity';
+
+describe('StopSharingUseCase', () => {
+  let useCase: StopSharingUseCase;
+  let etaRepository: jest.Mocked<IETARepository>;
+  let schoolRepository: jest.Mocked<ISchoolRepository>;
+  let getSchoolArrivalsUseCase: jest.Mocked<GetSchoolArrivalsUseCase>;
+  let arrivalsGateway: jest.Mocked<ArrivalsGateway>;
+
+  beforeEach(() => {
+    etaRepository = {
+      deleteByParentId: jest.fn(),
+    } as any;
+
+    schoolRepository = {
+      findById: jest.fn(),
+    } as any;
+
+    getSchoolArrivalsUseCase = {
+      execute: jest.fn(),
+    } as any;
+
+    arrivalsGateway = {
+      emitArrivalsUpdated: jest.fn(),
+    } as any;
+
+    useCase = new StopSharingUseCase(
+      etaRepository,
+      schoolRepository,
+      getSchoolArrivalsUseCase,
+      arrivalsGateway,
+    );
+  });
+
+  describe('execute', () => {
+    it('should delete ETA records for parent', async () => {
+      const input = {
+        parentId: 'parent-123',
+        schoolId: 'school-456',
+      };
+
+      const school: School = {
+        id: 'school-456',
+        name: 'Test School',
+        lat: -23.55052,
+        lng: -46.633308,
+        geofenceRadiusMeters: 100,
+        notificationThresholdMeters: 500,
+        createdAt: new Date(),
+      };
+
+      schoolRepository.findById.mockResolvedValue(school);
+      getSchoolArrivalsUseCase.execute.mockResolvedValue({
+        arrivals: [],
+        schoolName: 'Test School',
+        totalCount: 0,
+      });
+
+      const result = await useCase.execute(input);
+
+      expect(result.deleted).toBe(true);
+      expect(etaRepository.deleteByParentId).toHaveBeenCalledWith('parent-123');
+    });
+
+    it('should emit WebSocket notification after deletion', async () => {
+      const input = {
+        parentId: 'parent-123',
+        schoolId: 'school-456',
+      };
+
+      const school: School = {
+        id: 'school-456',
+        name: 'Test School',
+        lat: -23.55052,
+        lng: -46.633308,
+        geofenceRadiusMeters: 100,
+        notificationThresholdMeters: 500,
+        createdAt: new Date(),
+      };
+
+      const arrivalsOutput = {
+        arrivals: [],
+        schoolName: 'Test School',
+        totalCount: 0,
+      };
+
+      schoolRepository.findById.mockResolvedValue(school);
+      getSchoolArrivalsUseCase.execute.mockResolvedValue(arrivalsOutput);
+
+      await useCase.execute(input);
+
+      expect(getSchoolArrivalsUseCase.execute).toHaveBeenCalledWith({
+        schoolId: 'school-456',
+      });
+      expect(arrivalsGateway.emitArrivalsUpdated).toHaveBeenCalledWith(
+        'school-456',
+        [],
+        'Test School',
+      );
+    });
+
+    it('should not emit WebSocket if school not found', async () => {
+      const input = {
+        parentId: 'parent-123',
+        schoolId: 'school-456',
+      };
+
+      schoolRepository.findById.mockResolvedValue(null);
+
+      const result = await useCase.execute(input);
+
+      expect(result.deleted).toBe(true);
+      expect(etaRepository.deleteByParentId).toHaveBeenCalledWith('parent-123');
+      expect(getSchoolArrivalsUseCase.execute).not.toHaveBeenCalled();
+      expect(arrivalsGateway.emitArrivalsUpdated).not.toHaveBeenCalled();
+    });
+
+    it('should handle deletion when schoolId is empty', async () => {
+      const input = {
+        parentId: 'parent-123',
+        schoolId: '',
+      };
+
+      const result = await useCase.execute(input);
+
+      expect(result.deleted).toBe(true);
+      expect(etaRepository.deleteByParentId).toHaveBeenCalledWith('parent-123');
+      expect(schoolRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/domain/use-cases/stop-sharing.use-case.ts
+++ b/backend/src/domain/use-cases/stop-sharing.use-case.ts
@@ -1,0 +1,57 @@
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  IETARepository,
+  ETA_REPOSITORY,
+} from '../repositories/eta.repository.interface';
+import {
+  ISchoolRepository,
+  SCHOOL_REPOSITORY,
+} from '../repositories/school.repository.interface';
+import { GetSchoolArrivalsUseCase } from './get-school-arrivals.use-case';
+import { ArrivalsGateway } from '../../infrastructure/websocket/arrivals.gateway';
+
+export interface StopSharingInput {
+  parentId: string;
+  schoolId: string;
+}
+
+export interface StopSharingOutput {
+  deleted: boolean;
+}
+
+@Injectable()
+export class StopSharingUseCase {
+  constructor(
+    @Inject(ETA_REPOSITORY)
+    private readonly etaRepository: IETARepository,
+    @Inject(SCHOOL_REPOSITORY)
+    private readonly schoolRepository: ISchoolRepository,
+    private readonly getSchoolArrivalsUseCase: GetSchoolArrivalsUseCase,
+    private readonly arrivalsGateway: ArrivalsGateway,
+  ) {}
+
+  async execute(input: StopSharingInput): Promise<StopSharingOutput> {
+    // Delete all ETA records for the parent
+    await this.etaRepository.deleteByParentId(input.parentId);
+
+    // Notify school via WebSocket if schoolId is provided
+    if (input.schoolId) {
+      const school = await this.schoolRepository.findById(input.schoolId);
+      if (school) {
+        // Get updated arrivals queue (parent should no longer be included)
+        const arrivalsOutput = await this.getSchoolArrivalsUseCase.execute({
+          schoolId: input.schoolId,
+        });
+
+        // Emit WebSocket event to school room
+        this.arrivalsGateway.emitArrivalsUpdated(
+          input.schoolId,
+          arrivalsOutput.arrivals,
+          school.name,
+        );
+      }
+    }
+
+    return { deleted: true };
+  }
+}

--- a/backend/src/presentation/locations/locations.controller.spec.ts
+++ b/backend/src/presentation/locations/locations.controller.spec.ts
@@ -71,6 +71,7 @@ describe('LocationsController', () => {
     locationsServiceMock = {
       saveLocation: jest.fn(),
       getMyLatestLocation: jest.fn(),
+      stopSharing: jest.fn(),
     };
 
     calculateETAUseCaseMock = {
@@ -180,6 +181,48 @@ describe('LocationsController', () => {
         parentId: mockParentId,
       });
       expect(result).toEqual(mockCalculateETAOutput);
+    });
+  });
+
+  describe('stopSharing', () => {
+    it('should call stopSharing with parentId from JWT sub and return void', async () => {
+      // Arrange
+      locationsServiceMock.stopSharing.mockResolvedValue(undefined);
+
+      // Act
+      const result = await controller.stopSharing({ user: mockJwtPayload });
+
+      // Assert
+      expect(locationsServiceMock.stopSharing).toHaveBeenCalledWith(
+        mockParentId,
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should prefer id over sub when both are present in JWT', async () => {
+      // Arrange
+      const jwtWithId = { sub: 'sub-id', id: 'actual-id', email: 'x@x.com' };
+      locationsServiceMock.stopSharing.mockResolvedValue(undefined);
+
+      // Act
+      await controller.stopSharing({ user: jwtWithId });
+
+      // Assert
+      expect(locationsServiceMock.stopSharing).toHaveBeenCalledWith(
+        'actual-id',
+      );
+    });
+
+    it('should propagate errors from stopSharing service', async () => {
+      // Arrange
+      locationsServiceMock.stopSharing.mockRejectedValue(
+        new Error('Failed to stop sharing'),
+      );
+
+      // Act & Assert
+      await expect(
+        controller.stopSharing({ user: mockJwtPayload }),
+      ).rejects.toThrow('Failed to stop sharing');
     });
   });
 

--- a/backend/src/presentation/locations/locations.controller.ts
+++ b/backend/src/presentation/locations/locations.controller.ts
@@ -9,6 +9,7 @@ import {
   Request,
   HttpCode,
   HttpStatus,
+  Delete,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import {
@@ -63,6 +64,19 @@ export class LocationsController {
   ): Promise<LocationResponseDto | null> {
     const parentId = req.user.id ?? req.user.sub;
     return this.locationsService.getMyLatestLocation(parentId);
+  }
+
+  @Delete('me')
+  @ApiOperation({
+    summary: 'Stop location sharing',
+    description: 'Delete all ETA records and remove from arrivals queue',
+  })
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async stopSharing(@Request() req: { user: any }): Promise<void> {
+    const parentId = req.user.id ?? req.user.sub;
+    await this.locationsService.stopSharing(parentId);
   }
 
   @Post(':parentId/calculate-eta')

--- a/backend/src/presentation/locations/locations.module.ts
+++ b/backend/src/presentation/locations/locations.module.ts
@@ -6,6 +6,7 @@ import { CalculateETAUseCase } from '../../domain/use-cases/calculate-eta.use-ca
 import { GetArrivalsQueueUseCase } from '../../domain/use-cases/get-arrivals-queue.use-case';
 import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
 import { NotifySchoolUseCase } from '../../domain/use-cases/notify-school.use-case';
+import { StopSharingUseCase } from '../../domain/use-cases/stop-sharing.use-case';
 import { DataModule } from '../../data/data.module';
 import { OSRMModule } from '../../infrastructure/osrm/osrm.module';
 import { WebSocketModule } from '../../infrastructure/websocket/websocket.module';
@@ -48,6 +49,7 @@ import { ETA_REPOSITORY } from '../../domain/repositories/eta.repository.interfa
     GetArrivalsQueueUseCase,
     GetSchoolArrivalsUseCase,
     NotifySchoolUseCase,
+    StopSharingUseCase,
     {
       provide: 'IOSRMServiceAdapter',
       useClass: OSRMServiceAdapter,

--- a/backend/src/presentation/locations/locations.service.spec.ts
+++ b/backend/src/presentation/locations/locations.service.spec.ts
@@ -96,6 +96,7 @@ describe('LocationsService', () => {
       save: jest.fn(),
       findLatestByParentId: jest.fn(),
       findBySchoolId: jest.fn(),
+      deleteByParentId: jest.fn(),
     } as any;
 
     parentRepositoryMock = {
@@ -243,6 +244,62 @@ describe('LocationsService', () => {
       });
 
       expect(result.accuracy).toBeUndefined();
+    });
+  });
+
+  describe('stopSharing', () => {
+    it('should call stopSharingUseCase with parentId and schoolId from parent', async () => {
+      // Arrange
+      const parentId = 'parent-456';
+      parentRepositoryMock.findById.mockResolvedValue(mockParent);
+      stopSharingUseCaseMock.execute.mockResolvedValue({ deleted: true });
+
+      // Act
+      await service.stopSharing(parentId);
+
+      // Assert
+      expect(parentRepositoryMock.findById).toHaveBeenCalledWith(parentId);
+      expect(stopSharingUseCaseMock.execute).toHaveBeenCalledWith({
+        parentId,
+        schoolId: 'school-123',
+      });
+    });
+
+    it('should fall back to ETA schoolId when parent has no schoolId', async () => {
+      // Arrange
+      const parentId = 'parent-456';
+      const parentWithoutSchool: typeof mockParent = {
+        ...mockParent,
+        schoolId: undefined as any,
+      };
+      parentRepositoryMock.findById.mockResolvedValue(parentWithoutSchool);
+      etaRepositoryMock.findLatestByParentId.mockResolvedValue(mockETA);
+      stopSharingUseCaseMock.execute.mockResolvedValue({ deleted: true });
+
+      // Act
+      await service.stopSharing(parentId);
+
+      // Assert
+      expect(etaRepositoryMock.findLatestByParentId).toHaveBeenCalledWith(
+        parentId,
+      );
+      expect(stopSharingUseCaseMock.execute).toHaveBeenCalledWith({
+        parentId,
+        schoolId: 'school-123',
+      });
+    });
+
+    it('should throw when school cannot be determined', async () => {
+      // Arrange
+      const parentId = 'parent-456';
+      parentRepositoryMock.findById.mockResolvedValue(null);
+      etaRepositoryMock.findLatestByParentId.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.stopSharing(parentId)).rejects.toThrow(
+        `Cannot determine school for parent ${parentId}`,
+      );
+      expect(stopSharingUseCaseMock.execute).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/presentation/locations/locations.service.spec.ts
+++ b/backend/src/presentation/locations/locations.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { LocationsService } from './locations.service';
 import { SaveLocationWithETAUseCase } from '../../domain/use-cases/save-location-with-eta.use-case';
 import { NotifySchoolUseCase } from '../../domain/use-cases/notify-school.use-case';
+import { StopSharingUseCase } from '../../domain/use-cases/stop-sharing.use-case';
 import {
   ILocationRepository,
   LOCATION_REPOSITORY,
@@ -23,6 +24,7 @@ describe('LocationsService', () => {
   let service: LocationsService;
   let saveLocationWithETAUseCaseMock: jest.Mocked<SaveLocationWithETAUseCase>;
   let notifySchoolUseCaseMock: jest.Mocked<NotifySchoolUseCase>;
+  let stopSharingUseCaseMock: jest.Mocked<StopSharingUseCase>;
   let locationRepositoryMock: jest.Mocked<ILocationRepository>;
   let etaRepositoryMock: jest.Mocked<IETARepository>;
   let parentRepositoryMock: jest.Mocked<IParentRepository>;
@@ -78,6 +80,10 @@ describe('LocationsService', () => {
       execute: jest.fn(),
     } as any;
 
+    stopSharingUseCaseMock = {
+      execute: jest.fn(),
+    } as any;
+
     locationRepositoryMock = {
       save: jest.fn(),
       findById: jest.fn(),
@@ -110,6 +116,10 @@ describe('LocationsService', () => {
         {
           provide: NotifySchoolUseCase,
           useValue: notifySchoolUseCaseMock,
+        },
+        {
+          provide: StopSharingUseCase,
+          useValue: stopSharingUseCaseMock,
         },
         {
           provide: LOCATION_REPOSITORY,

--- a/backend/src/presentation/locations/locations.service.ts
+++ b/backend/src/presentation/locations/locations.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { SaveLocationWithETAUseCase } from '../../domain/use-cases/save-location-with-eta.use-case';
 import { NotifySchoolUseCase } from '../../domain/use-cases/notify-school.use-case';
+import { StopSharingUseCase } from '../../domain/use-cases/stop-sharing.use-case';
 import {
   ILocationRepository,
   LOCATION_REPOSITORY,
@@ -23,6 +24,7 @@ export class LocationsService {
   constructor(
     private readonly saveLocationWithETAUseCase: SaveLocationWithETAUseCase,
     private readonly notifySchoolUseCase: NotifySchoolUseCase,
+    private readonly stopSharingUseCase: StopSharingUseCase,
     @Inject(LOCATION_REPOSITORY)
     private readonly locationRepository: ILocationRepository,
     @Inject(ETA_REPOSITORY)
@@ -162,5 +164,25 @@ export class LocationsService {
     }
 
     return response;
+  }
+
+  async stopSharing(parentId: string): Promise<void> {
+    try {
+      // Get parent's school
+      const parent = await this.getParentWithSchool(parentId);
+
+      // Execute stop sharing use case
+      await this.stopSharingUseCase.execute({
+        parentId,
+        schoolId: parent.schoolId,
+      });
+
+      this.logger.log(
+        `Parent ${parentId} stopped sharing location for school ${parent.schoolId}`,
+      );
+    } catch (error) {
+      this.logger.error(`Failed to stop sharing: ${error.message}`);
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implements DELETE /locations/me endpoint to allow parents to explicitly stop sharing their location, removing them immediately from the arrivals queue.

## Changes

- Add `deleteByParentId` method to ETA repository interface and implementation
- Create `StopSharingUseCase` that deletes ETAs and emits WebSocket notification
- Add `stopSharing` method to `LocationsService`
- Add DELETE `/locations/me` endpoint (JWT protected, returns HTTP 204)
- Unit tests for new use case
- Update existing test mocks for new repository method

## Acceptance Criteria

- ✅ DELETE `/locations/me` with valid JWT returns HTTP 204
- ✅ Parent no longer appears in GET `/schools/:id/arrivals` after deletion
- ✅ WebSocket `arrivals:updated` event emitted to school room
- ✅ Returns HTTP 401 without valid JWT

## Testing

```bash
npm run lint    # PASS (0 warnings)
npm run build   # PASS
npm test        # PASS (122 tests)
```

Closes #206