### PR TITLE
feat(mobile): call DELETE /locations/me when location sharing is toggled off

### DIFF
--- a/mobile/src/data/repositories/__tests__/location.repository.spec.ts
+++ b/mobile/src/data/repositories/__tests__/location.repository.spec.ts
@@ -91,4 +91,28 @@ describe('LocationRepository', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('stopSharing', () => {
+    it('should call DELETE /locations/me', async () => {
+      mockHttpClient.delete.mockResolvedValue(undefined);
+
+      await repository.stopSharing();
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/locations/me');
+      expect(mockHttpClient.delete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate HTTP errors', async () => {
+      mockHttpClient.delete.mockRejectedValue(new Error('Network error'));
+
+      await expect(repository.stopSharing()).rejects.toThrow('Network error');
+    });
+
+    it('should propagate 401 errors (JWT expired)', async () => {
+      const error = new Error('Unauthorized');
+      mockHttpClient.delete.mockRejectedValue(error);
+
+      await expect(repository.stopSharing()).rejects.toThrow('Unauthorized');
+    });
+  });
 });

--- a/mobile/src/data/repositories/location.repository.ts
+++ b/mobile/src/data/repositories/location.repository.ts
@@ -42,6 +42,10 @@ export class LocationRepository implements ILocationRepository {
       return null;
     }
   }
+
+  async stopSharing(): Promise<void> {
+    await this.http.delete('/locations/me');
+  }
 }
 
 export const locationRepository = new LocationRepository();

--- a/mobile/src/domain/repositories/location.repository.interface.ts
+++ b/mobile/src/domain/repositories/location.repository.interface.ts
@@ -7,4 +7,5 @@ import { CurrentLocation } from '@domain/entities';
 export interface ILocationRepository {
   sendLocation(schoolId: string, location: CurrentLocation): Promise<void>;
   getMyLocation(): Promise<CurrentLocation | null>;
+  stopSharing(): Promise<void>;
 }

--- a/mobile/src/domain/usecases/__tests__/get-current-location.usecase.spec.ts
+++ b/mobile/src/domain/usecases/__tests__/get-current-location.usecase.spec.ts
@@ -10,6 +10,7 @@ describe('GetCurrentLocationUseCase', () => {
     mockLocationRepository = {
       sendLocation: jest.fn(),
       getMyLocation: jest.fn(),
+      stopSharing: jest.fn(),
     };
     useCase = new GetCurrentLocationUseCase(mockLocationRepository);
   });

--- a/mobile/src/domain/usecases/__tests__/send-location.usecase.spec.ts
+++ b/mobile/src/domain/usecases/__tests__/send-location.usecase.spec.ts
@@ -10,6 +10,7 @@ describe('SendLocationUseCase', () => {
     mockLocationRepository = {
       sendLocation: jest.fn(),
       getMyLocation: jest.fn(),
+      stopSharing: jest.fn(),
     };
     useCase = new SendLocationUseCase(mockLocationRepository);
   });

--- a/mobile/src/domain/usecases/__tests__/stop-sharing.usecase.spec.ts
+++ b/mobile/src/domain/usecases/__tests__/stop-sharing.usecase.spec.ts
@@ -1,0 +1,35 @@
+import { StopSharingUseCase } from '../stop-sharing.usecase';
+import { ILocationRepository } from '@domain/repositories';
+
+describe('StopSharingUseCase', () => {
+  let useCase: StopSharingUseCase;
+  let mockLocationRepository: jest.Mocked<ILocationRepository>;
+
+  beforeEach(() => {
+    mockLocationRepository = {
+      sendLocation: jest.fn(),
+      getMyLocation: jest.fn(),
+      stopSharing: jest.fn(),
+    };
+    useCase = new StopSharingUseCase(mockLocationRepository);
+  });
+
+  describe('execute', () => {
+    it('should call stopSharing on repository', async () => {
+      mockLocationRepository.stopSharing.mockResolvedValue(undefined);
+
+      await useCase.execute();
+
+      expect(mockLocationRepository.stopSharing).toHaveBeenCalledWith();
+      expect(mockLocationRepository.stopSharing).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate repository errors', async () => {
+      const error = new Error('Network error');
+
+      mockLocationRepository.stopSharing.mockRejectedValue(error);
+
+      await expect(useCase.execute()).rejects.toThrow('Network error');
+    });
+  });
+});

--- a/mobile/src/domain/usecases/index.ts
+++ b/mobile/src/domain/usecases/index.ts
@@ -1,4 +1,5 @@
 export { GetCurrentLocationUseCase } from './get-current-location.usecase';
 export { SendLocationUseCase } from './send-location.usecase';
+export { StopSharingUseCase } from './stop-sharing.usecase';
 export { GetArrivalsUseCase } from './get-arrivals.usecase';
 export { WatchSchoolArrivalsUseCase } from './watch-school-arrivals.usecase';

--- a/mobile/src/domain/usecases/stop-sharing.usecase.ts
+++ b/mobile/src/domain/usecases/stop-sharing.usecase.ts
@@ -1,0 +1,13 @@
+import { ILocationRepository } from '@domain/repositories';
+
+/**
+ * StopSharingUseCase
+ * Stops sharing the parent's location with the backend
+ */
+export class StopSharingUseCase {
+  constructor(private readonly locationRepository: ILocationRepository) {}
+
+  async execute(): Promise<void> {
+    return this.locationRepository.stopSharing();
+  }
+}

--- a/mobile/src/presentation/hooks/__tests__/useSendLocation.spec.ts
+++ b/mobile/src/presentation/hooks/__tests__/useSendLocation.spec.ts
@@ -1,10 +1,13 @@
 import { renderHook, act } from '@testing-library/react-native';
 import { useSendLocation } from '../useSendLocation';
 
-// Mock SendLocationUseCase
+// Mock SendLocationUseCase and StopSharingUseCase
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 jest.mock('@domain/usecases', () => ({
   SendLocationUseCase: jest.fn().mockImplementation(() => ({
+    execute: jest.fn().mockResolvedValue(undefined),
+  })),
+  StopSharingUseCase: jest.fn().mockImplementation(() => ({
     execute: jest.fn().mockResolvedValue(undefined),
   })),
 }));
@@ -14,6 +17,7 @@ jest.mock('@domain/usecases', () => ({
 jest.mock('@data/repositories', () => ({
   locationRepository: {
     sendLocation: jest.fn(),
+    stopSharing: jest.fn(),
   },
 }));
 
@@ -152,6 +156,56 @@ describe('useSendLocation', () => {
 
     await act(async () => {
       await send1Promise;
+    });
+  });
+
+  describe('stopSharing', () => {
+    it('should call StopSharingUseCase on stopSharing', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { StopSharingUseCase } = require('@domain/usecases');
+      const { result } = renderHook(() => useSendLocation());
+
+      await act(async () => {
+        await result.current.stopSharing();
+      });
+
+      expect(StopSharingUseCase).toHaveBeenCalled();
+    });
+
+    it('should succeed silently when StopSharingUseCase succeeds', async () => {
+      const { result } = renderHook(() => useSendLocation());
+
+      // Should not throw
+      await act(async () => {
+        await result.current.stopSharing();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it('should not throw when StopSharingUseCase fails (silent failure)', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { StopSharingUseCase } = require('@domain/usecases');
+
+      StopSharingUseCase.mockImplementationOnce(() => ({
+        execute: jest.fn().mockRejectedValue(new Error('Network error')),
+      }));
+
+      const { result } = renderHook(() => useSendLocation());
+
+      // Should NOT throw — silent failure
+      await act(async () => {
+        await result.current.stopSharing();
+      });
+
+      // Error state should remain null (stopSharing doesn't set error state)
+      expect(result.current.error).toBeNull();
+    });
+
+    it('should expose stopSharing in hook return value', () => {
+      const { result } = renderHook(() => useSendLocation());
+
+      expect(typeof result.current.stopSharing).toBe('function');
     });
   });
 });

--- a/mobile/src/presentation/hooks/useSendLocation.ts
+++ b/mobile/src/presentation/hooks/useSendLocation.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { CurrentLocation } from '@domain/entities';
-import { SendLocationUseCase } from '@domain/usecases';
+import { SendLocationUseCase, StopSharingUseCase } from '@domain/usecases';
 import { locationRepository } from '@data/repositories';
 
 export interface UseSendLocation {
@@ -8,6 +8,7 @@ export interface UseSendLocation {
   lastSentAt: number | null;
   error: string | null;
   sendLocation(schoolId: string, location: CurrentLocation): Promise<void>;
+  stopSharing(): Promise<void>;
 }
 
 export const useSendLocation = (): UseSendLocation => {
@@ -39,10 +40,21 @@ export const useSendLocation = (): UseSendLocation => {
     [isSending],
   );
 
+  const stopSharing = useCallback(async () => {
+    try {
+      const useCase = new StopSharingUseCase(locationRepository);
+      await useCase.execute();
+    } catch (err) {
+      // Silent failure - log but don't throw
+      console.warn('Failed to stop sharing:', err);
+    }
+  }, []);
+
   return {
     isSending,
     lastSentAt,
     error,
     sendLocation,
+    stopSharing,
   };
 };

--- a/mobile/src/presentation/screens/main/HomeScreen.tsx
+++ b/mobile/src/presentation/screens/main/HomeScreen.tsx
@@ -169,7 +169,7 @@ export function HomeScreen({ navigation }: HomeScreenProps): JSX.Element {
     stopTracking,
     error: locationError,
   } = useLocation();
-  const { lastSentAt, sendLocation } = useSendLocation();
+  const { lastSentAt, sendLocation, stopSharing } = useSendLocation();
   const [selectedSchool, setSelectedSchool] = useState<School | null>(null);
 
   // Load selectedSchool from AsyncStorage on mount
@@ -194,6 +194,7 @@ export function HomeScreen({ navigation }: HomeScreenProps): JSX.Element {
       startTracking(selectedSchool.location);
     } else {
       stopTracking();
+      void stopSharing();
     }
   };
 


### PR DESCRIPTION
## Summary

Implement mobile feature to call `DELETE /locations/me` when parent turns off location sharing toggle in HomeScreen. This ensures parents are removed from the arrivals queue immediately rather than waiting for ETA TTL expiration.

## Changes

- Add `stopSharing()` to `ILocationRepository` interface
- Implement `stopSharing()` in `LocationRepository` calling `DELETE /locations/me`
- Create `StopSharingUseCase` following Clean Architecture pattern
- Add `stopSharing` to `useSendLocation` hook with silent error handling
- Call `stopSharing` in `HomeScreen` when toggle is turned off
- Add unit tests for `StopSharingUseCase`
- Update existing repository mocks to include `stopSharing` method

## Test Plan

- [x] `npm run lint` passes (0 warnings)
- [x] `npm test` passes (89 tests, all passing)
- [x] Unit tests cover successful execution and error propagation
- [ ] Manual testing: Toggle location sharing off and verify parent disappears from arrivals
- [ ] Manual testing: Verify silent failure if API call fails (no crash, no error shown)

Closes #207