### PR TITLE
fix: load current school config in settings and fix exception filter status codes

### DIFF
--- a/backend/src/infrastructure/filters/all-exceptions.filter.ts
+++ b/backend/src/infrastructure/filters/all-exceptions.filter.ts
@@ -2,6 +2,7 @@ import {
   ExceptionFilter,
   Catch,
   ArgumentsHost,
+  HttpException,
   HttpStatus,
   Logger,
 } from '@nestjs/common';
@@ -21,9 +22,16 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    const statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
+    const statusCode =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
     const message =
-      exception instanceof Error ? exception.message : 'Internal server error';
+      exception instanceof HttpException
+        ? exception.message
+        : exception instanceof Error
+          ? exception.message
+          : 'Internal server error';
     const isProduction = process.env.NODE_ENV === 'production';
 
     // Log full error with stack trace (only used for debugging)

--- a/web/src/app/dashboard/[schoolId]/settings/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/settings/page.tsx
@@ -1,6 +1,7 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { TOKEN_KEY } from '@/lib/auth';
+import { getSchool } from '@/lib/server-api';
 import { SchoolSettingsForm } from '@/components/settings/SchoolSettingsForm';
 
 interface SettingsPageProps {
@@ -17,6 +18,8 @@ export default async function SettingsPage({ params }: SettingsPageProps) {
     redirect('/login');
   }
 
+  const school = await getSchool(schoolId).catch(() => null);
+
   return (
     <div className="p-8">
       <div className="mb-8">
@@ -26,7 +29,11 @@ export default async function SettingsPage({ params }: SettingsPageProps) {
         </p>
       </div>
 
-      <SchoolSettingsForm schoolId={schoolId} />
+      <SchoolSettingsForm
+        schoolId={schoolId}
+        initialGeofenceRadius={school?.geofenceRadiusMeters ?? 500}
+        initialNotificationThreshold={school?.notificationThresholdMeters ?? 300}
+      />
     </div>
   );
 }

--- a/web/src/components/settings/SchoolSettingsForm.tsx
+++ b/web/src/components/settings/SchoolSettingsForm.tsx
@@ -5,11 +5,17 @@ import { updateSchoolConfigAction } from '@/app/actions/update-school-config.act
 
 interface SchoolSettingsFormProps {
   schoolId: string;
+  initialGeofenceRadius: number;
+  initialNotificationThreshold: number;
 }
 
-export function SchoolSettingsForm({ schoolId }: SchoolSettingsFormProps) {
-  const [geofenceRadiusMeters, setGeofenceRadiusMeters] = useState<string>('500');
-  const [notificationThresholdMeters, setNotificationThresholdMeters] = useState<string>('300');
+export function SchoolSettingsForm({
+  schoolId,
+  initialGeofenceRadius,
+  initialNotificationThreshold,
+}: SchoolSettingsFormProps) {
+  const [geofenceRadiusMeters, setGeofenceRadiusMeters] = useState<string>(String(initialGeofenceRadius));
+  const [notificationThresholdMeters, setNotificationThresholdMeters] = useState<string>(String(initialNotificationThreshold));
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);

--- a/web/src/components/settings/__tests__/SchoolSettingsForm.test.tsx
+++ b/web/src/components/settings/__tests__/SchoolSettingsForm.test.tsx
@@ -15,7 +15,7 @@ describe('SchoolSettingsForm', () => {
   });
 
   it('renders form with default values', () => {
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const geofenceInput = screen.getByLabelText(/raio do geofence/i);
     const notificationInput = screen.getByLabelText(/distância para notificação/i);
@@ -25,7 +25,7 @@ describe('SchoolSettingsForm', () => {
   });
 
   it('renders submit button', () => {
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const submitButton = screen.getByRole('button', {
       name: /salvar configurações/i,
@@ -34,7 +34,7 @@ describe('SchoolSettingsForm', () => {
   });
 
   it('shows validation error for geofence radius below minimum', async () => {
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const geofenceInput = screen.getByLabelText(/raio do geofence/i);
     const submitButton = screen.getByRole('button', {
@@ -54,7 +54,7 @@ describe('SchoolSettingsForm', () => {
   });
 
   it('shows validation error for geofence radius above maximum', async () => {
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const geofenceInput = screen.getByLabelText(/raio do geofence/i);
     const submitButton = screen.getByRole('button', {
@@ -74,7 +74,7 @@ describe('SchoolSettingsForm', () => {
   });
 
   it('shows validation error for notification threshold below minimum', async () => {
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const notificationInput = screen.getByLabelText(/distância para notificação/i);
     const submitButton = screen.getByRole('button', {
@@ -94,7 +94,7 @@ describe('SchoolSettingsForm', () => {
   });
 
   it('shows validation error for notification threshold above maximum', async () => {
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const notificationInput = screen.getByLabelText(/distância para notificação/i);
     const submitButton = screen.getByRole('button', {
@@ -122,7 +122,7 @@ describe('SchoolSettingsForm', () => {
       },
     });
 
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const geofenceInput = screen.getByLabelText(/raio do geofence/i);
     const notificationInput = screen.getByLabelText(/distância para notificação/i);
@@ -154,7 +154,7 @@ describe('SchoolSettingsForm', () => {
       error: 'Erro no servidor',
     });
 
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const submitButton = screen.getByRole('button', {
       name: /salvar configurações/i,
@@ -173,7 +173,7 @@ describe('SchoolSettingsForm', () => {
         new Promise((resolve) => setTimeout(() => resolve({ success: true }), 100))
     );
 
-    render(<SchoolSettingsForm schoolId="school-123" />);
+    render(<SchoolSettingsForm schoolId="school-123" initialGeofenceRadius={500} initialNotificationThreshold={300} />);
 
     const geofenceInput = screen.getByLabelText(/raio do geofence/i);
     const notificationInput = screen.getByLabelText(/distância para notificação/i);

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -20,6 +20,8 @@ export interface School {
   id: string;
   name: string;
   location: SchoolLocation;
+  geofenceRadiusMeters: number;
+  notificationThresholdMeters: number;
 }
 
 export interface Arrival {


### PR DESCRIPTION
## Summary

- **Settings form** now loads current values from DB on page open — geofence radius and notification threshold reflect what's saved
- **School type** updated to include `geofenceRadiusMeters` and `notificationThresholdMeters`
- **AllExceptionsFilter** now returns correct HTTP status code for HttpExceptions instead of always returning 500 (fixes 401 Unauthorized showing as 500 in the web)

## Root Cause

- `SchoolSettingsForm` used hardcoded `useState('500')` and `useState('300')` — never loaded real values from backend
- `AllExceptionsFilter` had `const statusCode = HttpStatus.INTERNAL_SERVER_ERROR` hardcoded, swallowing all HttpException status codes

## Test Results

```
✅ Backend: 138 tests passed
✅ Web: 199 tests passed
✅ Backend lint: PASS
```