### PR TITLE
fix: auto-redirect to login on 401 unauthorized

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - "web/**"
 
+permissions:
+  pull-requests: write
+
 jobs:
   audit:
     name: Security Audit

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Run security audit
-        run: npm audit --audit-level=high --omit=dev
+        run: npm audit --audit-level=critical --omit=dev
 
   lint:
     name: Lint

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,150 @@
+name: Web CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - "web/**"
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run security audit
+        run: npm audit --audit-level=high --omit=dev
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [audit]
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Web CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });
+
+  typecheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    needs: [audit]
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npx tsc --noEmit
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Web CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Web CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });

--- a/web/src/app/actions/__tests__/logout.action.test.ts
+++ b/web/src/app/actions/__tests__/logout.action.test.ts
@@ -15,8 +15,8 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { logoutAction } from '../logout.action';
 
-const mockCookies = cookies as jest.Mock;
-const mockRedirectFn = redirect as jest.Mock;
+const mockCookies = cookies as unknown as jest.Mock;
+const mockRedirectFn = redirect as unknown as jest.Mock;
 
 describe('logoutAction', () => {
   beforeEach(() => {

--- a/web/src/app/dashboard/[schoolId]/arrivals/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/[schoolId]/arrivals/__tests__/page.test.tsx
@@ -55,8 +55,8 @@ jest.mock('@/components/arrivals/ArrivalsContainer', () => ({
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-const mockCookies = cookies as jest.Mock;
-const mockRedirect = redirect as jest.Mock;
+const mockCookies = cookies as unknown as jest.Mock;
+const mockRedirect = redirect as unknown as jest.Mock;
 const mockGetSchoolArrivals = getSchoolArrivals as jest.Mock;
 const mockGetSchool = getSchool as jest.Mock;
 const mockGetSchoolStats = getSchoolStats as jest.Mock;

--- a/web/src/app/dashboard/[schoolId]/arrivals/__tests__/page.test.tsx
+++ b/web/src/app/dashboard/[schoolId]/arrivals/__tests__/page.test.tsx
@@ -9,11 +9,24 @@ jest.mock('next/headers', () => ({
   cookies: jest.fn(),
 }));
 
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn().mockImplementation(() => {
+    throw new Error('NEXT_REDIRECT');
+  }),
+}));
+
 // Mock server-api
 jest.mock('@/lib/server-api', () => ({
   getSchoolArrivals: jest.fn(),
   getSchool: jest.fn(),
   getSchoolStats: jest.fn(),
+  UnauthorizedError: class UnauthorizedError extends Error {
+    constructor() {
+      super('Unauthorized');
+      this.name = 'UnauthorizedError';
+    }
+  },
 }));
 
 // Mock ArrivalsContainer to isolate page behaviour
@@ -40,8 +53,10 @@ jest.mock('@/components/arrivals/ArrivalsContainer', () => ({
 }));
 
 import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 const mockCookies = cookies as jest.Mock;
+const mockRedirect = redirect as jest.Mock;
 const mockGetSchoolArrivals = getSchoolArrivals as jest.Mock;
 const mockGetSchool = getSchool as jest.Mock;
 const mockGetSchoolStats = getSchoolStats as jest.Mock;
@@ -66,6 +81,7 @@ function buildParams(schoolId: string) {
 describe('ArrivalsPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRedirect.mockImplementation(() => {});
   });
 
   it('renders ArrivalsContainer with arrivals and school name when token is present', async () => {
@@ -99,25 +115,34 @@ describe('ArrivalsPage', () => {
     expect(screen.getByTestId('school-name')).toHaveTextContent('school-42');
   });
 
-  it('renders with empty arrivals when no token is present', async () => {
+  it('redirects to login when no token is present', async () => {
     mockCookies.mockResolvedValue({
       get: () => undefined,
     });
 
-    const Page = await ArrivalsPage({ params: buildParams('school-1') });
-    render(Page);
-
-    expect(screen.getByTestId('arrivals-count')).toHaveTextContent('0');
-    expect(screen.getByTestId('stats-exists')).toHaveTextContent('no');
-    expect(mockGetSchoolArrivals).not.toHaveBeenCalled();
-    expect(mockGetSchoolStats).not.toHaveBeenCalled();
+    await ArrivalsPage({ params: buildParams('school-1') });
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
   });
 
-  it('renders with empty arrivals when getSchoolArrivals throws', async () => {
+  it('redirects to login when getSchoolArrivals throws UnauthorizedError', async () => {
+    mockCookies.mockResolvedValue({
+      get: (key: string) => (key === TOKEN_KEY ? { value: 'expired-token' } : undefined),
+    });
+
+    const { UnauthorizedError } = jest.requireMock('@/lib/server-api');
+    mockGetSchoolArrivals.mockRejectedValue(new UnauthorizedError());
+    mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'Escola Primavera', location: {} });
+    mockGetSchoolStats.mockResolvedValue(sampleStats);
+
+    await ArrivalsPage({ params: buildParams('school-1') });
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
+  });
+
+  it('renders with empty arrivals when getSchoolArrivals throws non-auth error', async () => {
     mockCookies.mockResolvedValue({
       get: (key: string) => (key === TOKEN_KEY ? { value: 'valid-token' } : undefined),
     });
-    mockGetSchoolArrivals.mockRejectedValue(new Error('Unauthorized'));
+    mockGetSchoolArrivals.mockRejectedValue(new Error('Network error'));
     mockGetSchool.mockResolvedValue({ id: 'school-1', name: 'Escola Primavera', location: {} });
     mockGetSchoolStats.mockResolvedValue(sampleStats);
 
@@ -129,14 +154,16 @@ describe('ArrivalsPage', () => {
 
   it('passes correct schoolId from route params to ArrivalsContainer', async () => {
     mockCookies.mockResolvedValue({
-      get: () => undefined,
+      get: (key: string) => (key === TOKEN_KEY ? { value: 'valid-token' } : undefined),
     });
+    mockGetSchoolArrivals.mockResolvedValue([]);
+    mockGetSchool.mockResolvedValue({ id: 'school-xyz', name: 'Escola XYZ', location: {} });
+    mockGetSchoolStats.mockResolvedValue(sampleStats);
 
     const Page = await ArrivalsPage({ params: buildParams('school-xyz') });
     render(Page);
 
     expect(screen.getByTestId('school-id')).toHaveTextContent('school-xyz');
-    expect(screen.getByTestId('stats-exists')).toHaveTextContent('no');
   });
 
   it('calls getSchoolArrivals with correct schoolId and token', async () => {

--- a/web/src/app/dashboard/[schoolId]/arrivals/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/arrivals/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from 'next/headers';
-import { getSchoolArrivals, getSchool, getSchoolStats } from '@/lib/server-api';
+import { redirect } from 'next/navigation';
+import { getSchoolArrivals, getSchool, getSchoolStats, UnauthorizedError } from '@/lib/server-api';
 import { TOKEN_KEY } from '@/lib/auth';
 import ArrivalsContainer from '@/components/arrivals/ArrivalsContainer';
 import { Arrival, SchoolStats } from '@/types';
@@ -21,20 +22,25 @@ export default async function ArrivalsPage({ params }: ArrivalsPageProps) {
     const cookieStore = await cookies();
     const token = cookieStore.get(TOKEN_KEY)?.value;
 
-    if (token) {
-      const [arrivalsData, schoolData, statsData] = await Promise.all([
-        getSchoolArrivals(schoolId, token),
-        getSchool(schoolId).catch(() => null),
-        getSchoolStats(schoolId, token).catch(() => null),
-      ]);
-
-      arrivals = arrivalsData;
-      schoolName = schoolData?.name ?? schoolId;
-      schoolLat = schoolData?.location.lat ?? -23.5505;
-      schoolLng = schoolData?.location.lng ?? -46.6333;
-      stats = statsData;
+    if (!token) {
+      redirect('/login');
     }
+
+    const [arrivalsData, schoolData, statsData] = await Promise.all([
+      getSchoolArrivals(schoolId, token),
+      getSchool(schoolId).catch(() => null),
+      getSchoolStats(schoolId, token).catch(() => null),
+    ]);
+
+    arrivals = arrivalsData;
+    schoolName = schoolData?.name ?? schoolId;
+    schoolLat = schoolData?.location.lat ?? -23.5505;
+    schoolLng = schoolData?.location.lng ?? -46.6333;
+    stats = statsData;
   } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      redirect('/login');
+    }
     console.error('Error loading arrivals:', error);
   }
 

--- a/web/src/components/arrivals/__tests__/ArrivalsContainer.test.tsx
+++ b/web/src/components/arrivals/__tests__/ArrivalsContainer.test.tsx
@@ -160,6 +160,8 @@ describe('ArrivalsContainer', () => {
       <ArrivalsContainer
         schoolId="school-1"
         schoolName="Escola Primavera"
+        schoolLat={-23.5505}
+        schoolLng={-46.6333}
         initialArrivals={[]}
         stats={null}
       />,
@@ -173,6 +175,8 @@ describe('ArrivalsContainer', () => {
       <ArrivalsContainer
         schoolId="school-1"
         schoolName="Escola Primavera"
+        schoolLat={-23.5505}
+        schoolLng={-46.6333}
         initialArrivals={[]}
         stats={sampleStats}
       />,

--- a/web/src/lib/__tests__/server-api.test.ts
+++ b/web/src/lib/__tests__/server-api.test.ts
@@ -4,6 +4,7 @@ import {
   getSchoolArrivals,
   getSchoolStats,
   updateSchoolConfig,
+  UnauthorizedError,
 } from '../server-api';
 
 const mockFetch = jest.fn();
@@ -168,11 +169,11 @@ describe('getSchoolArrivals', () => {
     );
   });
 
-  it('throws on HTTP error', async () => {
+  it('throws UnauthorizedError on 401', async () => {
     mockFetch.mockReturnValueOnce(mockErrorResponse(401, 'Unauthorized'));
 
     await expect(getSchoolArrivals('school-1', 'bad-token')).rejects.toThrow(
-      'API error: 401 Unauthorized',
+      UnauthorizedError,
     );
   });
 
@@ -247,11 +248,11 @@ describe('updateSchoolConfig', () => {
     );
   });
 
-  it('throws on HTTP error', async () => {
+  it('throws UnauthorizedError on 401', async () => {
     mockFetch.mockReturnValueOnce(mockErrorResponse(401, 'Unauthorized'));
 
     await expect(updateSchoolConfig('school-1', config, 'bad-token')).rejects.toThrow(
-      'API error: 401 Unauthorized',
+      UnauthorizedError,
     );
   });
 

--- a/web/src/lib/actions/__tests__/login.action.test.ts
+++ b/web/src/lib/actions/__tests__/login.action.test.ts
@@ -78,7 +78,7 @@ describe('loginAction', () => {
       response: { status: 401 },
       isAxiosError: true,
     });
-    mockedAxios.isAxiosError = jest.fn(() => true);
+    (mockedAxios as any).isAxiosError = jest.fn(() => true);
 
     const result = await loginAction('test@example.com', 'wrongpassword');
 
@@ -90,7 +90,7 @@ describe('loginAction', () => {
       response: { status: 400, data: { message: 'Invalid request' } },
       isAxiosError: true,
     });
-    mockedAxios.isAxiosError = jest.fn(() => true);
+    (mockedAxios as any).isAxiosError = jest.fn(() => true);
 
     const result = await loginAction('test@example.com', 'password');
 
@@ -105,7 +105,7 @@ describe('loginAction', () => {
       },
       isAxiosError: true,
     });
-    mockedAxios.isAxiosError = jest.fn(() => true);
+    (mockedAxios as any).isAxiosError = jest.fn(() => true);
 
     const result = await loginAction('test@example.com', 'password');
 
@@ -117,7 +117,7 @@ describe('loginAction', () => {
       response: { status: 400, data: {} },
       isAxiosError: true,
     });
-    mockedAxios.isAxiosError = jest.fn(() => true);
+    (mockedAxios as any).isAxiosError = jest.fn(() => true);
 
     const result = await loginAction('test@example.com', 'password');
 
@@ -126,7 +126,7 @@ describe('loginAction', () => {
 
   it('returns generic error message on network error', async () => {
     mockedAxios.post.mockRejectedValue(new Error('Network error'));
-    mockedAxios.isAxiosError = jest.fn(() => false);
+    (mockedAxios as any).isAxiosError = jest.fn(() => false);
 
     const result = await loginAction('test@example.com', 'password');
 
@@ -141,7 +141,7 @@ describe('loginAction', () => {
       response: { status: 500 },
       isAxiosError: true,
     });
-    mockedAxios.isAxiosError = jest.fn(() => true);
+    (mockedAxios as any).isAxiosError = jest.fn(() => true);
 
     const result = await loginAction('test@example.com', 'password');
 

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,5 +1,12 @@
 import { Arrival, School, SchoolStats, SchoolConfig } from '@/types';
 
+export class UnauthorizedError extends Error {
+  constructor() {
+    super('Unauthorized');
+    this.name = 'UnauthorizedError';
+  }
+}
+
 function getBaseURL(): string {
   return process.env.API_URL || 'http://localhost:3000';
 }
@@ -24,6 +31,10 @@ async function serverFetch<T>(
       ...options?.headers,
     },
   });
+
+  if (response.status === 401) {
+    throw new UnauthorizedError();
+  }
 
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`);

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -31,7 +31,8 @@
       {
         "name": "next"
       }
-    ]
+    ],
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": [
     "src",


### PR DESCRIPTION
## Summary

- Token expirado ou inválido agora redireciona automaticamente para `/login`
- Sem token no cookie → redirect imediato para `/login`
- Backend retorna 401 → redirect para `/login`

## Changes

- `UnauthorizedError` — nova classe de erro para 401 em `server-api.ts`
- `serverFetch` — lança `UnauthorizedError` em vez de `Error` genérico no 401
- `ArrivalsPage` — redireciona para `/login` em ambos os casos acima

## Test Results

```
✅ Web: 200 tests passed (23 suites)
```