### PR TITLE
fix(backend): include config fields in GET /schools/:id response

### DIFF
--- a/backend/src/presentation/schools/dtos/school-response.dto.ts
+++ b/backend/src/presentation/schools/dtos/school-response.dto.ts
@@ -76,4 +76,16 @@ export class SchoolListResponseDto {
     type: SchoolLocationDto,
   })
   location: SchoolLocationDto;
+
+  @ApiProperty({
+    example: 1000,
+    description: 'Geofence radius in meters',
+  })
+  geofenceRadiusMeters: number;
+
+  @ApiProperty({
+    example: 500,
+    description: 'Notification threshold in meters',
+  })
+  notificationThresholdMeters: number;
 }

--- a/backend/src/presentation/schools/schools.controller.spec.ts
+++ b/backend/src/presentation/schools/schools.controller.spec.ts
@@ -595,11 +595,15 @@ describe('SchoolsController', () => {
           id: 'school-1',
           name: 'School A',
           location: { lat: -23.5505, lng: -46.6333 },
+          geofenceRadiusMeters: 1000,
+          notificationThresholdMeters: 500,
         },
         {
           id: 'school-2',
           name: 'School B',
           location: { lat: -23.551, lng: -46.634 },
+          geofenceRadiusMeters: 1000,
+          notificationThresholdMeters: 500,
         },
       ]);
       expect(listSchoolsUseCaseMock.execute).toHaveBeenCalled();

--- a/backend/src/presentation/schools/schools.controller.ts
+++ b/backend/src/presentation/schools/schools.controller.ts
@@ -87,6 +87,8 @@ export class SchoolsController {
         lat: school.lat,
         lng: school.lng,
       },
+      geofenceRadiusMeters: school.geofenceRadiusMeters,
+      notificationThresholdMeters: school.notificationThresholdMeters,
     }));
   }
 
@@ -108,6 +110,8 @@ export class SchoolsController {
         lat: school.lat,
         lng: school.lng,
       },
+      geofenceRadiusMeters: school.geofenceRadiusMeters,
+      notificationThresholdMeters: school.notificationThresholdMeters,
     };
   }
 


### PR DESCRIPTION
## Problem

The settings page always displayed the default values (500m / 300m) instead of the real values saved in the database.

## Root cause

The `GET /schools/:id` (and `GET /schools`) endpoint returned `SchoolListResponseDto` without `geofenceRadiusMeters` and `notificationThresholdMeters`. The `School` entity and use case had the data, but the controller discarded them during mapping.

As a result, `school?.geofenceRadiusMeters` was always `undefined` on the settings page, falling back to the hardcoded default (`?? 500`).

## Fix

- Added `geofenceRadiusMeters` and `notificationThresholdMeters` to `SchoolListResponseDto`
- Included both fields in the return of `listSchools` and `getSchool` controller methods
- Updated controller spec to assert the new fields

## Testing

- `npm run build` ✅
- `npm test` — 138/138 ✅