### PR TITLE
fix(backend): fix INTERVAL parameter binding in ETA repository queries

### DIFF
--- a/backend/src/data/repositories/eta.repository.spec.ts
+++ b/backend/src/data/repositories/eta.repository.spec.ts
@@ -255,7 +255,7 @@ describe('ETARepository', () => {
 
       expect(result).toEqual(expectedEntity);
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "eta.calculatedAt > NOW() - INTERVAL ':maxAgeMinutes minutes'",
+        "eta.calculatedAt > NOW() - (:maxAgeMinutes * INTERVAL '1 minute')",
         { maxAgeMinutes },
       );
       expect(ETAMapper.toDomain).toHaveBeenCalledWith(mockModel);
@@ -498,7 +498,7 @@ describe('ETARepository', () => {
       );
 
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "eta.calculatedAt > NOW() - INTERVAL ':maxAgeMinutes minutes'",
+        "eta.calculatedAt > NOW() - (:maxAgeMinutes * INTERVAL '1 minute')",
         { maxAgeMinutes },
       );
       expect(result.size).toBe(1);
@@ -582,7 +582,7 @@ describe('ETARepository', () => {
 
       expect(result.size).toBe(0);
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        "eta.calculatedAt > NOW() - INTERVAL ':maxAgeMinutes minutes'",
+        "eta.calculatedAt > NOW() - (:maxAgeMinutes * INTERVAL '1 minute')",
         { maxAgeMinutes },
       );
     });

--- a/backend/src/data/repositories/eta.repository.ts
+++ b/backend/src/data/repositories/eta.repository.ts
@@ -34,7 +34,7 @@ export class ETARepository implements IETARepository {
 
     if (maxAgeMinutes !== undefined && maxAgeMinutes !== null) {
       queryBuilder.andWhere(
-        "eta.calculatedAt > NOW() - INTERVAL ':maxAgeMinutes minutes'",
+        "eta.calculatedAt > NOW() - (:maxAgeMinutes * INTERVAL '1 minute')",
         { maxAgeMinutes },
       );
     }
@@ -69,7 +69,7 @@ export class ETARepository implements IETARepository {
 
     if (maxAgeMinutes !== undefined && maxAgeMinutes !== null) {
       queryBuilder.andWhere(
-        "eta.calculatedAt > NOW() - INTERVAL ':maxAgeMinutes minutes'",
+        "eta.calculatedAt > NOW() - (:maxAgeMinutes * INTERVAL '1 minute')",
         { maxAgeMinutes },
       );
     }


### PR DESCRIPTION
## Problem

`GET /schools/:id/arrivals` and `GET /schools/:id/stats` were returning 500 with:

```
QueryFailedError: bind message supplies 2 parameters, but prepared statement "" requires 1
```

## Root cause

TypeORM replaces named parameters (`:maxAgeMinutes`) with positional ones (`$2`), but PostgreSQL does not accept bind parameters inside `INTERVAL` string literals:

```sql
-- broken: PostgreSQL sees INTERVAL '$2 minutes' — rejects the bind param
eta.calculatedAt > NOW() - INTERVAL ':maxAgeMinutes minutes'
```

## Fix

Replace with a multiplication form that binds the parameter correctly:

```sql
-- fixed: $2 is used as a numeric multiplier, outside the INTERVAL literal
eta.calculatedAt > NOW() - (:maxAgeMinutes * INTERVAL '1 minute')
```

Applies to both `findLatestByParentId` and `findLatestBulkByParentIds`.

## Testing

- `npm run build` ✅
- `npm test` — 138/138 ✅