### PR TITLE
fix(web): place parent marker at start of polyline, not end

### DIFF
--- a/web/src/components/map/ParentMarker.tsx
+++ b/web/src/components/map/ParentMarker.tsx
@@ -58,7 +58,7 @@ export default function ParentMarker({
     return null;
   }
 
-  const parentPosition = coordinates[coordinates.length - 1];
+  const parentPosition = coordinates[0];
   const color = getMarkerColor(arrival.durationMinutes);
   const icon = createMarkerIcon(color);
 

--- a/web/src/components/map/__tests__/ParentMarker.test.tsx
+++ b/web/src/components/map/__tests__/ParentMarker.test.tsx
@@ -165,14 +165,14 @@ describe('ParentMarker', () => {
   });
 
   describe('parent position from polyline', () => {
-    it('uses last point of decoded polyline as parent position', () => {
+    it('uses first point of decoded polyline as parent position', () => {
       mockPolylineDecode.mockReturnValue([
         [-23.551, -46.634],
         [-23.552, -46.635],
         [-23.5505, -46.6333],
       ]);
 
-      // Renders without crashing — parent position is last coordinate
+      // Renders without crashing — parent position is first coordinate (start of route)
       render(<ParentMarker {...defaultProps} />);
       expect(screen.getByTestId('marker')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Problem

The parent marker on the arrivals map was not showing the parent's real position.

## Root cause

The OSRM route is calculated **from parent → school**, so:
- `coordinates[0]` = parent's current location (route start)
- `coordinates[length - 1]` = school location (route end)

`ParentMarker` was using `coordinates[length - 1]`, placing the marker at the school's coordinates — on top of the school pin — instead of the parent's actual location.

## Fix

Changed to `coordinates[0]` so the marker correctly reflects the parent's current position.

## Testing

- `npm test` — 18/18 (ParentMarker) ✅
- `npm test` — 200/200 (full suite) ✅