### PR TITLE
fix: end-to-end real-time arrivals integration

### DIFF
--- a/backend/src/data/models/eta.model.ts
+++ b/backend/src/data/models/eta.model.ts
@@ -24,7 +24,7 @@ export class ETAModel {
 
   @Column({
     name: 'calculated_at',
-    type: 'timestamp',
+    type: 'timestamptz',
     default: () => 'CURRENT_TIMESTAMP',
   })
   calculatedAt: Date;

--- a/backend/src/data/models/location.model.ts
+++ b/backend/src/data/models/location.model.ts
@@ -26,6 +26,6 @@ export class LocationModel {
   @Column('float', { nullable: true })
   accuracy: number;
 
-  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  @Column({ type: 'timestamptz', default: () => 'CURRENT_TIMESTAMP' })
   timestamp: Date;
 }

--- a/backend/src/infrastructure/websocket/arrivals.gateway.ts
+++ b/backend/src/infrastructure/websocket/arrivals.gateway.ts
@@ -99,6 +99,7 @@ export class ArrivalsGateway
         lng: arrival.lng,
         etaMinutes: arrival.etaMinutes,
         distanceMeters: arrival.distanceMeters,
+        routePolyline: arrival.routePolyline,
         calculatedAt: arrival.calculatedAt,
       })),
       timestamp: new Date(),

--- a/backend/src/presentation/locations/locations.module.ts
+++ b/backend/src/presentation/locations/locations.module.ts
@@ -10,6 +10,7 @@ import { StopSharingUseCase } from '../../domain/use-cases/stop-sharing.use-case
 import { DataModule } from '../../data/data.module';
 import { OSRMModule } from '../../infrastructure/osrm/osrm.module';
 import { WebSocketModule } from '../../infrastructure/websocket/websocket.module';
+import { ArrivalsGateway } from '../../infrastructure/websocket/arrivals.gateway';
 import { OSRMServiceAdapter } from '../../infrastructure/osrm/osrm-service.adapter';
 import { LOCATION_REPOSITORY } from '../../domain/repositories/location.repository.interface';
 import { SCHOOL_REPOSITORY } from '../../domain/repositories/school.repository.interface';
@@ -48,7 +49,12 @@ import { ETA_REPOSITORY } from '../../domain/repositories/eta.repository.interfa
     CalculateETAUseCase,
     GetArrivalsQueueUseCase,
     GetSchoolArrivalsUseCase,
-    NotifySchoolUseCase,
+    {
+      provide: NotifySchoolUseCase,
+      useFactory: (getSchoolArrivals, schoolRepo, arrivalsGateway) =>
+        new NotifySchoolUseCase(getSchoolArrivals, schoolRepo, arrivalsGateway),
+      inject: [GetSchoolArrivalsUseCase, SCHOOL_REPOSITORY, ArrivalsGateway],
+    },
     StopSharingUseCase,
     {
       provide: 'IOSRMServiceAdapter',

--- a/mobile/src/infrastructure/http/config.ts
+++ b/mobile/src/infrastructure/http/config.ts
@@ -7,11 +7,11 @@ function getApiBaseUrl(): string {
       Constants.expoConfig?.hostUri ?? Constants.manifest2?.extra?.expoGo?.debuggerHost;
     const host = debuggerHost?.split(':')[0];
     if (host) {
-      return `http://${host}:3000`;
+      return `http://${host}:3001`;
     }
   }
   // Fallback / production
-  return 'http://localhost:3000';
+  return 'http://localhost:3001';
 }
 
 export const API_BASE_URL = getApiBaseUrl();

--- a/mobile/src/presentation/hooks/useSendLocation.ts
+++ b/mobile/src/presentation/hooks/useSendLocation.ts
@@ -45,7 +45,6 @@ export const useSendLocation = (): UseSendLocation => {
       const useCase = new StopSharingUseCase(locationRepository);
       await useCase.execute();
     } catch (err) {
-      // Silent failure - log but don't throw
       console.warn('Failed to stop sharing:', err);
     }
   }, []);

--- a/mobile/src/presentation/screens/main/HomeScreen.tsx
+++ b/mobile/src/presentation/screens/main/HomeScreen.tsx
@@ -194,7 +194,10 @@ export function HomeScreen({ navigation }: HomeScreenProps): JSX.Element {
       startTracking(selectedSchool.location);
     } else {
       stopTracking();
-      void stopSharing();
+      void (async () => {
+        await new Promise((r) => setTimeout(r, 2000));
+        await stopSharing();
+      })();
     }
   };
 

--- a/web/src/components/arrivals/ArrivalsContainer.tsx
+++ b/web/src/components/arrivals/ArrivalsContainer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { Arrival, SchoolStats } from '@/types';
 import { useArrivals } from '@/hooks/useArrivals';
@@ -36,6 +37,20 @@ export default function ArrivalsContainer({
     token,
   );
 
+  const liveStats = useMemo<SchoolStats | null>(() => {
+    if (arrivals.length === 0 && !lastUpdatedAt) return stats;
+    const totalParents = arrivals.length;
+    const etaValues = arrivals.map((a) => a.durationMinutes);
+    const avgETA = totalParents > 0 ? Math.round(etaValues.reduce((s, v) => s + v, 0) / totalParents) : 0;
+    return {
+      totalParents,
+      avgETA,
+      etaLessThan5Min: etaValues.filter((v) => v < 5).length,
+      eta5To15Min: etaValues.filter((v) => v >= 5 && v <= 15).length,
+      etaGreaterThan15Min: etaValues.filter((v) => v > 15).length,
+    };
+  }, [arrivals, stats, lastUpdatedAt]);
+
   return (
     <div className="p-8">
       <h1 className="text-3xl font-bold text-gray-900 mb-4">{schoolName}</h1>
@@ -49,7 +64,7 @@ export default function ArrivalsContainer({
         arrivals={arrivals}
       />
 
-      <ArrivalsStats stats={stats} />
+      <ArrivalsStats stats={liveStats} />
 
       <ArrivalsQueue arrivals={arrivals} />
     </div>

--- a/web/src/hooks/useArrivals.ts
+++ b/web/src/hooks/useArrivals.ts
@@ -28,6 +28,7 @@ interface GatewayArrival {
   lng: number;
   etaMinutes: number;
   distanceMeters: number;
+  routePolyline?: string;
   calculatedAt?: string;
 }
 
@@ -44,7 +45,7 @@ function mapGatewayArrivals(payload: ArrivalsUpdatedPayload): Arrival[] {
     parentId: a.parentId,
     distanceMeters: a.distanceMeters,
     durationMinutes: a.etaMinutes,
-    routePolyline: '',
+    routePolyline: a.routePolyline || '',
   }));
 }
 
@@ -65,6 +66,7 @@ export function useArrivals(
   const [isConnected, setIsConnected] = useState(false);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
+  // WebSocket connection
   useEffect(() => {
     const secureUrl = getSecureWsUrl(getWsUrl());
 
@@ -97,6 +99,27 @@ export function useArrivals(
       socket.disconnect();
     };
   }, [schoolId, token]);
+
+  // Clear stale arrivals when no update received within TTL (5 min)
+  useEffect(() => {
+    if (!lastUpdatedAt || arrivals.length === 0) return;
+
+    const TTL_MS = 5 * 60 * 1000;
+    const elapsed = Date.now() - lastUpdatedAt.getTime();
+    const remaining = TTL_MS - elapsed;
+
+    if (remaining <= 0) {
+      setArrivals([]);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setArrivals([]);
+      setLastUpdatedAt(new Date());
+    }, remaining);
+
+    return () => clearTimeout(timer);
+  }, [lastUpdatedAt, arrivals.length]);
 
   return { arrivals, isConnected, lastUpdatedAt };
 }


### PR DESCRIPTION
## Problem

The real-time arrivals feature was broken across multiple layers — the web dashboard never showed parent pins, stats didn't update, and toggling off location sharing didn't remove the parent from the dashboard.

## Root causes and fixes

### Backend
- **Timezone mismatch**: `calculated_at` and `timestamp` columns were `timestamp without time zone`, but `NOW()` returns UTC. ETAs saved in local time were always filtered as "expired" by the 5-min TTL. Fixed by changing columns to `timestamptz`.
- **Missing routePolyline in WebSocket**: The `ArrivalsGateway` omitted `routePolyline` from the `arrivals:updated` payload, so `ParentMarker` rendered nothing on the map.
- **NotifySchoolUseCase injection**: `schoolRepository` was `undefined` because the use case wasn't using `@Injectable()`. Fixed with `useFactory` pattern.

### Mobile
- **Wrong API port**: Mobile pointed to port 3000 (default), backend runs on 3001.
- **Race condition on toggle off**: Background task created a new ETA after `stopSharing` deleted them. Added 2s delay to let in-flight POST complete.

### Web
- **Static stats**: Stats were only loaded server-side on page load, never updated via WebSocket. Now computed in real-time from arrivals data.
- **Missing polyline mapping**: `useArrivals` mapped `routePolyline` as empty string. Now maps the field from the gateway payload.
- **Stale arrivals**: Dashboard kept showing parent indefinitely after sharing stopped. Added 5-min TTL cleanup timer.

## Known limitations

- Navigating between schools while sharing creates duplicate background tasks (tracked in separate issue)
- Privacy radius is hardcoded at 1000m instead of using school's geofenceRadiusMeters

## Testing

- Toggle ON → parent appears on web map with pin and route ✅
- Toggle OFF → parent disappears from web after ~2s ✅
- No location updates for 5min → web auto-clears arrivals ✅
- Stats update in real-time ✅
- Backend tests: 138/138 ✅
- Web tests: 201/201 ✅