### PR TITLE
feat: add AdminJwtStrategy and AdminJwtAuthGuard for multi-role auth

### DIFF
--- a/backend/src/infrastructure/auth/admin-jwt-auth.guard.spec.ts
+++ b/backend/src/infrastructure/auth/admin-jwt-auth.guard.spec.ts
@@ -1,0 +1,14 @@
+import { AdminJwtAuthGuard } from './admin-jwt-auth.guard';
+
+describe('AdminJwtAuthGuard', () => {
+  it('should be defined', () => {
+    const guard = new AdminJwtAuthGuard();
+    expect(guard).toBeDefined();
+  });
+
+  it('should extend AuthGuard with jwt-admin strategy', () => {
+    const guard = new AdminJwtAuthGuard();
+    // Verify guard is an instance that inherits from AuthGuard('jwt-admin')
+    expect(guard).toBeInstanceOf(AdminJwtAuthGuard);
+  });
+});

--- a/backend/src/infrastructure/auth/admin-jwt-auth.guard.ts
+++ b/backend/src/infrastructure/auth/admin-jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class AdminJwtAuthGuard extends AuthGuard('jwt-admin') {}

--- a/backend/src/infrastructure/auth/admin-jwt.strategy.spec.ts
+++ b/backend/src/infrastructure/auth/admin-jwt.strategy.spec.ts
@@ -1,0 +1,169 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AdminJwtStrategy } from './admin-jwt.strategy';
+import { JwtPayload } from './jwt-payload.interface';
+import { User } from '../../domain/entities/user.entity';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../../domain/repositories/user.repository.interface';
+
+describe('AdminJwtStrategy', () => {
+  let strategy: AdminJwtStrategy;
+  let userRepositoryMock: jest.Mocked<IUserRepository>;
+
+  const mockUser: User = {
+    id: 'user-123',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    role: 'school_admin',
+    schoolId: 'school-456',
+    createdAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    userRepositoryMock = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      create: jest.fn(),
+      validateCredentials: jest.fn(),
+    } as jest.Mocked<IUserRepository>;
+
+    const configServiceMock = {
+      get: jest.fn().mockReturnValue('test-jwt-secret'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminJwtStrategy,
+        {
+          provide: USER_REPOSITORY,
+          useValue: userRepositoryMock,
+        },
+        {
+          provide: ConfigService,
+          useValue: configServiceMock,
+        },
+      ],
+    }).compile();
+
+    strategy = module.get<AdminJwtStrategy>(AdminJwtStrategy);
+  });
+
+  describe('validate', () => {
+    it('should return user for valid admin token with school_admin role', async () => {
+      const payload: JwtPayload = {
+        sub: 'user-123',
+        email: 'admin@example.com',
+        role: 'school_admin',
+      };
+
+      userRepositoryMock.findById.mockResolvedValue(mockUser);
+
+      const result = await strategy.validate(payload);
+
+      expect(result).toEqual(mockUser);
+      expect(userRepositoryMock.findById).toHaveBeenCalledWith('user-123');
+    });
+
+    it('should return user for valid admin token with super_admin role', async () => {
+      const superAdminUser: User = {
+        ...mockUser,
+        id: 'user-super',
+        role: 'super_admin',
+        schoolId: null,
+      };
+
+      const payload: JwtPayload = {
+        sub: 'user-super',
+        email: 'super@example.com',
+        role: 'super_admin',
+      };
+
+      userRepositoryMock.findById.mockResolvedValue(superAdminUser);
+
+      const result = await strategy.validate(payload);
+
+      expect(result).toEqual(superAdminUser);
+      expect(userRepositoryMock.findById).toHaveBeenCalledWith('user-super');
+    });
+
+    it('should throw UnauthorizedException when role is parent (cross-isolation)', async () => {
+      const payload: JwtPayload = {
+        sub: 'parent-123',
+        email: 'parent@example.com',
+        role: 'parent',
+      };
+
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        'Invalid token for admin endpoint',
+      );
+      expect(userRepositoryMock.findById).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedException when role is undefined (cross-isolation)', async () => {
+      const payload: JwtPayload = {
+        sub: 'user-123',
+        email: 'user@example.com',
+        // role not set
+      };
+
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        'Invalid token for admin endpoint',
+      );
+      expect(userRepositoryMock.findById).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedException when user is not found in repository', async () => {
+      const payload: JwtPayload = {
+        sub: 'non-existent-user',
+        email: 'ghost@example.com',
+        role: 'school_admin',
+      };
+
+      userRepositoryMock.findById.mockResolvedValue(null);
+
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        'User not found',
+      );
+      expect(userRepositoryMock.findById).toHaveBeenCalledWith(
+        'non-existent-user',
+      );
+    });
+
+    it('should not call userRepository when role is parent', async () => {
+      const payload: JwtPayload = {
+        sub: 'parent-123',
+        email: 'parent@example.com',
+        role: 'parent',
+      };
+
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(userRepositoryMock.findById).not.toHaveBeenCalled();
+    });
+
+    it('should not call userRepository when role is absent', async () => {
+      const payload: JwtPayload = {
+        sub: 'some-user',
+        email: 'user@example.com',
+      };
+
+      await expect(strategy.validate(payload)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(userRepositoryMock.findById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/infrastructure/auth/admin-jwt.strategy.ts
+++ b/backend/src/infrastructure/auth/admin-jwt.strategy.ts
@@ -1,0 +1,42 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Inject } from '@nestjs/common';
+import { JwtPayload } from './jwt-payload.interface';
+import { User } from '../../domain/entities/user.entity';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../../domain/repositories/user.repository.interface';
+
+@Injectable()
+export class AdminJwtStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
+  constructor(
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+    private readonly configService: ConfigService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get<string>('JWT_SECRET'),
+    });
+  }
+
+  async validate(payload: JwtPayload): Promise<User> {
+    const { sub, role } = payload;
+
+    // Cross-isolation: reject parent tokens
+    if (!role || role === 'parent') {
+      throw new UnauthorizedException('Invalid token for admin endpoint');
+    }
+
+    const user = await this.userRepository.findById(sub);
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    return user;
+  }
+}

--- a/backend/src/infrastructure/auth/jwt-payload.interface.ts
+++ b/backend/src/infrastructure/auth/jwt-payload.interface.ts
@@ -1,5 +1,6 @@
 export interface JwtPayload {
-  sub: string; // parent id
+  sub: string; // parent id or user id
   email: string;
   schoolId?: string | null;
+  role?: string; // 'parent' | 'school_admin' | 'super_admin'
 }


### PR DESCRIPTION
## Summary
- Add `role` field to `JwtPayload` interface for cross-isolation
- Create `AdminJwtStrategy` with strategy name `'jwt-admin'`
- Create `AdminJwtAuthGuard` extending Passport `AuthGuard`

## Implementation Details
- **AdminJwtStrategy**: Uses `USER_REPOSITORY` for admin user lookup, rejects tokens without role or with `role === 'parent'`
- **AdminJwtAuthGuard**: Simple guard wrapping the `'jwt-admin'` strategy
- **JwtPayload**: Added optional `role` field for backward compatibility

## Test Plan
- [x] Lint passes (0 warnings)
- [x] Build passes (TypeScript compile)
- [x] Unit tests pass (154 tests)
- [ ] Integration testing with admin endpoints (Phase 3)

## Architecture
Follows Clean Architecture:
- Domain: No changes (User entity from NSD-96)
- Infrastructure: New strategy and guard in auth layer
- Follows existing pattern from `JwtStrategy` and `JwtAuthGuard`

Closes #230