### PR TITLE
[TASK-111] - Fase 2 - feat(web): switch login to admin auth endpoint

### DIFF
--- a/web/src/hooks/__tests__/useLogin.test.ts
+++ b/web/src/hooks/__tests__/useLogin.test.ts
@@ -25,7 +25,11 @@ describe('useLogin', () => {
 
   it('sets isLoading=true while loginAction is in flight', async () => {
     const mockLoginAction = loginModule.loginAction as jest.Mock;
-    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-123' });
+    mockLoginAction.mockResolvedValue({
+      success: true,
+      schoolId: 'school-123',
+      role: 'school_admin',
+    });
 
     const { result } = renderHook(() => useLogin());
 
@@ -46,9 +50,13 @@ describe('useLogin', () => {
     expect(result.current.isLoading).toBe(true);
   });
 
-  it('calls router.push with correct dashboard URL on success', async () => {
+  it('calls router.push with dashboard URL for school_admin', async () => {
     const mockLoginAction = loginModule.loginAction as jest.Mock;
-    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-456' });
+    mockLoginAction.mockResolvedValue({
+      success: true,
+      schoolId: 'school-456',
+      role: 'school_admin',
+    });
 
     const { result } = renderHook(() => useLogin());
 
@@ -57,6 +65,23 @@ describe('useLogin', () => {
     });
 
     expect(mockRouter.push).toHaveBeenCalledWith('/dashboard/school-456/arrivals');
+  });
+
+  it('calls router.push with admin URL for super_admin', async () => {
+    const mockLoginAction = loginModule.loginAction as jest.Mock;
+    mockLoginAction.mockResolvedValue({
+      success: true,
+      schoolId: null,
+      role: 'super_admin',
+    });
+
+    const { result } = renderHook(() => useLogin());
+
+    await act(async () => {
+      await result.current.login('test@example.com', 'password');
+    });
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/admin/schools');
   });
 
   it('sets error message on login failure', async () => {
@@ -88,7 +113,11 @@ describe('useLogin', () => {
     expect(result.current.error).toBe('Error');
 
     // Second login attempt clears error during submission
-    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-123' });
+    mockLoginAction.mockResolvedValue({
+      success: true,
+      schoolId: 'school-123',
+      role: 'school_admin',
+    });
     await act(async () => {
       await result.current.login('test@example.com', 'correctpassword');
     });
@@ -98,7 +127,11 @@ describe('useLogin', () => {
 
   it('does not set isLoading to false on success (router.push handles navigation)', async () => {
     const mockLoginAction = loginModule.loginAction as jest.Mock;
-    mockLoginAction.mockResolvedValue({ success: true, schoolId: 'school-123' });
+    mockLoginAction.mockResolvedValue({
+      success: true,
+      schoolId: 'school-123',
+      role: 'school_admin',
+    });
 
     const { result } = renderHook(() => useLogin());
 

--- a/web/src/hooks/useLogin.ts
+++ b/web/src/hooks/useLogin.ts
@@ -20,7 +20,15 @@ export function useLogin(): {
     const result = await loginAction(email, password);
 
     if (result.success) {
-      router.push(`/dashboard/${result.schoolId}/arrivals`);
+      // Route based on role
+      if (result.role === 'super_admin') {
+        router.push('/admin/schools');
+      } else if (result.role === 'school_admin' && result.schoolId) {
+        router.push(`/dashboard/${result.schoolId}/arrivals`);
+      } else {
+        setError('Usuário não tem role definido');
+        setIsLoading(false);
+      }
     } else {
       setError(result.error);
       setIsLoading(false);

--- a/web/src/lib/actions/__tests__/login.action.test.ts
+++ b/web/src/lib/actions/__tests__/login.action.test.ts
@@ -21,24 +21,28 @@ describe('loginAction', () => {
     mockedCookies.mockResolvedValue(mockCookieStore);
   });
 
-  it('returns success with schoolId on successful login', async () => {
+  it('returns success with schoolId and role on successful login', async () => {
     mockedAxios.post.mockResolvedValue({
       data: {
         accessToken: 'jwt-token-123',
-        parent: { schoolId: 'school-456' },
+        user: { schoolId: 'school-456', role: 'school_admin' },
       },
     });
 
     const result = await loginAction('test@example.com', 'password123');
 
-    expect(result).toEqual({ success: true, schoolId: 'school-456' });
+    expect(result).toEqual({
+      success: true,
+      schoolId: 'school-456',
+      role: 'school_admin',
+    });
   });
 
   it('sets onmyway_token cookie on successful login', async () => {
     mockedAxios.post.mockResolvedValue({
       data: {
         accessToken: 'jwt-token-123',
-        parent: { schoolId: 'school-456' },
+        user: { schoolId: 'school-456', role: 'school_admin' },
       },
     });
 
@@ -60,14 +64,14 @@ describe('loginAction', () => {
     mockedAxios.post.mockResolvedValue({
       data: {
         accessToken: 'jwt-token-123',
-        parent: { schoolId: 'school-456' },
+        user: { schoolId: 'school-456', role: 'school_admin' },
       },
     });
 
     await loginAction('test@example.com', 'password123');
 
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      expect.stringContaining('/auth/login'),
+      expect.stringContaining('/admin/auth/login'),
       { email: 'test@example.com', password: 'password123' },
       expect.any(Object)
     );
@@ -155,7 +159,7 @@ describe('loginAction', () => {
     mockedAxios.post.mockResolvedValue({
       data: {
         accessToken: 'jwt-token-123',
-        parent: { schoolId: 'school-456' },
+        user: { schoolId: 'school-456', role: 'school_admin' },
       },
     });
 

--- a/web/src/lib/actions/login.action.ts
+++ b/web/src/lib/actions/login.action.ts
@@ -8,10 +8,13 @@ const baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
 export async function loginAction(
   email: string,
   password: string,
-): Promise<{ success: true; schoolId: string } | { success: false; error: string }> {
+): Promise<
+  { success: true; schoolId: string | null; role: string }
+  | { success: false; error: string }
+> {
   try {
     const response = await axios.post(
-      `${baseURL}/auth/login`,
+      `${baseURL}/admin/auth/login`,
       { email, password },
       {
         timeout: 10000,
@@ -21,7 +24,7 @@ export async function loginAction(
       },
     );
 
-    const { accessToken, parent } = response.data;
+    const { accessToken, user } = response.data;
 
     // Set the cookie on the server
     const cookieStore = await cookies();
@@ -33,7 +36,11 @@ export async function loginAction(
       sameSite: 'strict',
     });
 
-    return { success: true, schoolId: parent.schoolId };
+    return {
+      success: true,
+      schoolId: user.schoolId || null,
+      role: user.role,
+    };
   } catch (error) {
     // Handle different error scenarios
     if (axios.isAxiosError(error)) {

--- a/web/src/lib/jwt.ts
+++ b/web/src/lib/jwt.ts
@@ -1,4 +1,6 @@
 export interface JWTPayload {
+  sub?: string;
+  role?: string;
   schoolId?: string;
   [key: string]: any;
 }


### PR DESCRIPTION
## Summary

Switch the web portal login from parent auth (`/auth/login`) to admin auth (`/admin/auth/login`).

**Phase 2.1 of Multi-Role Architecture**
- Login endpoint changed to `/admin/auth/login`
- Response parsing: `parent` object → `user` object
- JWT payload now includes `role` and `sub` fields
- Login routing: super_admin → `/admin/schools`, school_admin → `/dashboard/{schoolId}/arrivals`

## Changes

- **loginAction**: 
  - Endpoint: `/auth/login` → `/admin/auth/login`
  - Parse `user` instead of `parent` from response
  - Return `role` field along with `schoolId`

- **jwt.ts**:
  - Add `sub`, `role` to `JWTPayload` interface

- **useLogin hook**:
  - Route based on role: super_admin goes to `/admin/schools`
  - school_admin goes to `/dashboard/{schoolId}/arrivals`

## Verification

- Web login now calls `/admin/auth/login`
- Seeded super-admin user can login
- Existing parent login no longer works (expected — parents use mobile)

## Dependencies

- Depends on #231 (TASK-109: Admin auth)
- Depends on #232 (TASK-110: Seed script)

## Reference

- Issue: #233
- Architecture: Backend MULTI-ROLE-ARCHITECTURE.md

Closes #233