### PR TITLE
feat(web): role-based middleware routing #234

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -19,23 +19,44 @@ function decodeJWT(token: string) {
 
 export function middleware(request: NextRequest) {
   const token = request.cookies.get('onmyway_token')?.value;
+  const pathname = request.nextUrl.pathname;
 
-  // Protected paths
-  if (request.nextUrl.pathname.startsWith('/dashboard')) {
+  // Protect /admin/* paths - requires super_admin role
+  if (pathname.startsWith('/admin')) {
+    if (!token) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+
+    const payload = decodeJWT(token);
+    if (payload?.role !== 'super_admin') {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+  }
+
+  // Protect /dashboard/* paths - requires authentication
+  if (pathname.startsWith('/dashboard')) {
     if (!token) {
       return NextResponse.redirect(new URL('/login', request.url));
     }
   }
 
-  // Public paths: redirect to dashboard if already authenticated
-  if (request.nextUrl.pathname === '/login') {
+  // Public paths: redirect to appropriate dashboard based on role if already authenticated
+  if (pathname === '/login') {
     if (token) {
       const payload = decodeJWT(token);
-      const schoolId = payload?.schoolId;
-      if (schoolId) {
-        return NextResponse.redirect(new URL(`/dashboard/${schoolId}/arrivals`, request.url));
+
+      if (payload?.role === 'super_admin') {
+        return NextResponse.redirect(new URL('/admin/schools', request.url));
       }
-      return NextResponse.redirect(new URL('/dashboard', request.url));
+
+      if (payload?.role === 'school_admin' && payload?.schoolId) {
+        return NextResponse.redirect(
+          new URL(`/dashboard/${payload.schoolId}/arrivals`, request.url),
+        );
+      }
+
+      // Fallback for unknown roles
+      return NextResponse.redirect(new URL('/login', request.url));
     }
   }
 
@@ -43,5 +64,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/dashboard/:path*', '/login'],
+  matcher: ['/dashboard/:path*', '/admin/:path*', '/login'],
 };

--- a/web/src/__tests__/middleware.test.ts
+++ b/web/src/__tests__/middleware.test.ts
@@ -5,13 +5,24 @@ import { middleware } from '../../middleware';
 import { NextRequest, NextResponse } from 'next/server';
 
 // JWT tokens with known payloads (unsigned — decode-only)
-// payload: {"sub":"parent-123","email":"test@test.com","schoolId":"school-456"}
-const TOKEN_WITH_SCHOOL_ID =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJwYXJlbnQtMTIzIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwic2Nob29sSWQiOiJzY2hvb2wtNDU2In0.fake-sig';
+// payload: {"sub":"user-123","role":"super_admin"}
+const TOKEN_SUPER_ADMIN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTEyMyIsInJvbGUiOiJzdXBlcl9hZG1pbiJ9.fake-sig';
 
-// payload: {"sub":"parent-123","email":"test@test.com"}
-const TOKEN_WITHOUT_SCHOOL_ID =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJwYXJlbnQtMTIzIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIn0.fake-sig';
+// payload: {"sub":"user-456","role":"school_admin","schoolId":"school-456"}
+const TOKEN_SCHOOL_ADMIN_WITH_SCHOOL_ID =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTQ1NiIsInJvbGUiOiJzY2hvb2xfYWRtaW4iLCJzY2hvb2xJZCI6InNjaG9vbC00NTYifQ.fake-sig';
+
+// payload: {"sub":"user-789","role":"school_admin"}
+const TOKEN_SCHOOL_ADMIN_WITHOUT_SCHOOL_ID =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTc4OSIsInJvbGUiOiJzY2hvb2xfYWRtaW4ifQ.fake-sig';
+
+// payload: {"sub":"parent-123","role":"parent","schoolId":"school-456"}
+const TOKEN_PARENT_WITH_SCHOOL_ID =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJwYXJlbnQtMTIzIiwicm9sZSI6InBhcmVudCIsInNjaG9vbElkIjoic2Nob29sLTQ1NiJ9.fake-sig';
+
+// payload: {"invalid":"token"}
+const MALFORMED_TOKEN = 'not.a.valid.jwt.at.all';
 
 function makeRequest(pathname: string, token?: string): NextRequest {
   const url = `http://localhost:3001${pathname}`;
@@ -33,11 +44,17 @@ describe('middleware', () => {
       expect(res.headers.get('location')).toContain('/login');
     });
 
-    it('allows through when a token is present on /dashboard', () => {
-      const req = makeRequest('/dashboard/school-456/arrivals', TOKEN_WITH_SCHOOL_ID);
+    it('allows through when school_admin token is present on /dashboard', () => {
+      const req = makeRequest('/dashboard/school-456/arrivals', TOKEN_SCHOOL_ADMIN_WITH_SCHOOL_ID);
       const res = middleware(req);
 
-      // NextResponse.next() returns 200
+      expect(res.status).toBe(200);
+    });
+
+    it('allows through when super_admin token is present on /dashboard', () => {
+      const req = makeRequest('/dashboard/school-456/arrivals', TOKEN_SUPER_ADMIN);
+      const res = middleware(req);
+
       expect(res.status).toBe(200);
     });
 
@@ -49,23 +66,77 @@ describe('middleware', () => {
     });
   });
 
+  describe('/admin/* protected routes', () => {
+    it('redirects to /login when accessing /admin/schools without token', () => {
+      const req = makeRequest('/admin/schools');
+      const res = middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login');
+    });
+
+    it('allows through for super_admin on /admin/schools', () => {
+      const req = makeRequest('/admin/schools', TOKEN_SUPER_ADMIN);
+      const res = middleware(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('allows through for super_admin on nested /admin paths', () => {
+      const req = makeRequest('/admin/schools/123/edit', TOKEN_SUPER_ADMIN);
+      const res = middleware(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('redirects to /login for school_admin on /admin/schools', () => {
+      const req = makeRequest('/admin/schools', TOKEN_SCHOOL_ADMIN_WITH_SCHOOL_ID);
+      const res = middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login');
+    });
+
+    it('redirects to /login when token is malformed on /admin route', () => {
+      const req = makeRequest('/admin/schools', MALFORMED_TOKEN);
+      const res = middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login');
+    });
+  });
+
   describe('/login route', () => {
-    it('redirects to /dashboard/{schoolId}/arrivals when token contains schoolId', () => {
-      const req = makeRequest('/login', TOKEN_WITH_SCHOOL_ID);
+    it('redirects to /admin/schools for super_admin', () => {
+      const req = makeRequest('/login', TOKEN_SUPER_ADMIN);
+      const res = middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/admin/schools');
+    });
+
+    it('redirects to /dashboard/{schoolId}/arrivals for school_admin with schoolId', () => {
+      const req = makeRequest('/login', TOKEN_SCHOOL_ADMIN_WITH_SCHOOL_ID);
       const res = middleware(req);
 
       expect(res.status).toBe(307);
       expect(res.headers.get('location')).toContain('/dashboard/school-456/arrivals');
     });
 
-    it('redirects to /dashboard fallback when token has no schoolId', () => {
-      const req = makeRequest('/login', TOKEN_WITHOUT_SCHOOL_ID);
+    it('redirects to /login for school_admin without schoolId', () => {
+      const req = makeRequest('/login', TOKEN_SCHOOL_ADMIN_WITHOUT_SCHOOL_ID);
       const res = middleware(req);
 
       expect(res.status).toBe(307);
-      const location = res.headers.get('location');
-      expect(location).toContain('/dashboard');
-      expect(location).not.toContain('/dashboard/');
+      expect(res.headers.get('location')).toContain('/login');
+    });
+
+    it('redirects to /login for parent role', () => {
+      const req = makeRequest('/login', TOKEN_PARENT_WITH_SCHOOL_ID);
+      const res = middleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toContain('/login');
     });
 
     it('allows through (no redirect) when no token is present', () => {
@@ -75,19 +146,18 @@ describe('middleware', () => {
       expect(res.status).toBe(200);
     });
 
-    it('redirects to /dashboard fallback when token is malformed', () => {
-      const req = makeRequest('/login', 'not.a.valid.jwt.at.all');
+    it('redirects to /login when token is malformed', () => {
+      const req = makeRequest('/login', MALFORMED_TOKEN);
       const res = middleware(req);
 
-      // malformed token → decodeJWT returns null → fallback redirect
       expect(res.status).toBe(307);
-      expect(res.headers.get('location')).toContain('/dashboard');
+      expect(res.headers.get('location')).toContain('/login');
     });
   });
 
   describe('other routes', () => {
     it('passes through unmatched routes regardless of token', () => {
-      const req = makeRequest('/some-other-path', TOKEN_WITH_SCHOOL_ID);
+      const req = makeRequest('/some-other-path', TOKEN_SCHOOL_ADMIN_WITH_SCHOOL_ID);
       const res = middleware(req);
 
       expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

- Implement role-based routing in Next.js middleware
- Super-admin users are routed to /admin/schools dashboard
- School-admin users are routed to /dashboard/{schoolId}/arrivals
- /admin/* paths are protected and require super_admin role
- All middleware is updated to decode JWT role field and make routing decisions

## Test plan

- [x] All 210 web tests passing (16 middleware-specific tests)
- [x] Middleware correctly routes super_admin to /admin/schools on login
- [x] Middleware correctly routes school_admin to /dashboard/{schoolId}/arrivals on login
- [x] /admin/* paths reject non-super_admin users
- [x] /dashboard/* paths require authentication but allow any authenticated user

Closes #234