### PR TITLE
feat(backend): roles decorator + authorization guards #236

### DIFF
--- a/backend/src/infrastructure/auth/roles.decorator.ts
+++ b/backend/src/infrastructure/auth/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/backend/src/infrastructure/auth/roles.guard.spec.ts
+++ b/backend/src/infrastructure/auth/roles.guard.spec.ts
@@ -1,0 +1,127 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+  });
+
+  it('allows access when no @Roles metadata is present', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: 'school_admin' } }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(undefined);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('allows access when user role matches required role', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: 'super_admin' } }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['super_admin']);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('allows access when user role is in required roles list', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: 'school_admin' } }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue(['super_admin', 'school_admin']);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('denies access when user role does not match required role', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { role: 'school_admin' } }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['super_admin']);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it('denies access when user has no role', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: { id: 'user-123' } }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['super_admin']);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it('denies access when user is null', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: null }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['super_admin']);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it('denies access when request has no user', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({}),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['super_admin']);
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+});

--- a/backend/src/infrastructure/auth/roles.guard.ts
+++ b/backend/src/infrastructure/auth/roles.guard.ts
@@ -1,0 +1,30 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // If no @Roles metadata, allow access (permissive default)
+    if (!requiredRoles) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    // User must have a role and it must be in the allowed list
+    if (!user || !user.role) {
+      return false;
+    }
+
+    return requiredRoles.includes(user.role);
+  }
+}

--- a/backend/src/infrastructure/auth/roles.guard.ts
+++ b/backend/src/infrastructure/auth/roles.guard.ts
@@ -7,10 +7,10 @@ export class RolesGuard implements CanActivate {
   constructor(private reflector: Reflector) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
-      context.getHandler(),
-      context.getClass(),
-    ]);
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
 
     // If no @Roles metadata, allow access (permissive default)
     if (!requiredRoles) {

--- a/backend/src/infrastructure/auth/school-access.guard.spec.ts
+++ b/backend/src/infrastructure/auth/school-access.guard.spec.ts
@@ -1,0 +1,131 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { SchoolAccessGuard } from './school-access.guard';
+
+describe('SchoolAccessGuard', () => {
+  let guard: SchoolAccessGuard;
+
+  beforeEach(() => {
+    guard = new SchoolAccessGuard();
+  });
+
+  it('allows super_admin to access any school', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: { role: 'super_admin', schoolId: null },
+          params: { schoolId: 'school-999' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('allows school_admin to access their own school', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: { role: 'school_admin', schoolId: 'school-123' },
+          params: { schoolId: 'school-123' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('denies school_admin from accessing other schools', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: { role: 'school_admin', schoolId: 'school-123' },
+          params: { schoolId: 'school-456' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it('throws ForbiddenException when schoolId param is missing', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: { role: 'school_admin', schoolId: 'school-123' },
+          params: {},
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it('denies access for users with no role', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: { id: 'user-123' },
+          params: { schoolId: 'school-123' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it('denies access when user is null', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: null,
+          params: { schoolId: 'school-123' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it('denies access when request has no user', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          params: { schoolId: 'school-123' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(false);
+  });
+
+  it('throws ForbiddenException with descriptive message for mismatched schoolId', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: { role: 'school_admin', schoolId: 'school-123' },
+          params: { schoolId: 'school-999' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    try {
+      guard.canActivate(context);
+      fail('Should have thrown ForbiddenException');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ForbiddenException);
+      expect(error.message).toContain(
+        'School admin can only access their own school',
+      );
+    }
+  });
+});

--- a/backend/src/infrastructure/auth/school-access.guard.ts
+++ b/backend/src/infrastructure/auth/school-access.guard.ts
@@ -1,0 +1,33 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+
+@Injectable()
+export class SchoolAccessGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    // Super admin has access to all schools
+    if (user?.role === 'super_admin') {
+      return true;
+    }
+
+    // School admin must have matching schoolId
+    if (user?.role === 'school_admin') {
+      const requestedSchoolId = request.params.schoolId;
+
+      if (!requestedSchoolId) {
+        throw new ForbiddenException('schoolId route param is required');
+      }
+
+      if (user.schoolId !== requestedSchoolId) {
+        throw new ForbiddenException(
+          'School admin can only access their own school',
+        );
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/backend/src/infrastructure/auth/school-access.guard.ts
+++ b/backend/src/infrastructure/auth/school-access.guard.ts
@@ -1,4 +1,9 @@
-import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
 
 @Injectable()
 export class SchoolAccessGuard implements CanActivate {


### PR DESCRIPTION
## Summary

Implement the authorization infrastructure layer for role-based access control:

- **@Roles decorator** — Mark endpoints with required roles
- **RolesGuard** — Check user.role against allowed roles
- **SchoolAccessGuard** — Enforce school isolation
  - super_admin: access all schools
  - school_admin: access only their school

## Implementation Details

**RolesGuard:**
- Uses Reflector to read @Roles metadata from handlers/controllers
- Permissive default (no metadata = allow)
- Checks user.role is in allowed list
- Works with both JwtAuthGuard and AdminJwtAuthGuard

**SchoolAccessGuard:**
- Super admin bypasses all checks
- School admin checks route param schoolId matches user.schoolId
- Throws ForbiddenException on mismatch
- Requires schoolId in route params

## Test Plan

- [x] 183 backend tests passing (+15 new)
- [x] RolesGuard: role matching, mismatch, missing user
- [x] SchoolAccessGuard: super_admin bypass, school_admin isolation
- [x] Error cases: missing params, missing user, invalid roles

Closes #236