### PR TITLE
feat(backend): invite code on schools + registration

### DIFF
--- a/backend/src/domain/use-cases/get-school.use-case.spec.ts
+++ b/backend/src/domain/use-cases/get-school.use-case.spec.ts
@@ -1,0 +1,53 @@
+import { NotFoundException } from '@nestjs/common';
+import { GetSchoolUseCase } from './get-school.use-case';
+
+const mockSchool = {
+  id: 'school-123',
+  name: 'Test School',
+  location: { lat: -23.5505, lng: -46.6333 },
+  geofenceRadiusMeters: 500,
+  notificationThresholdMeters: 1000,
+};
+
+describe('GetSchoolUseCase', () => {
+  let useCase: GetSchoolUseCase;
+  let mockSchoolRepository: any;
+
+  beforeEach(() => {
+    mockSchoolRepository = {
+      findById: jest.fn(),
+    };
+
+    useCase = new GetSchoolUseCase(mockSchoolRepository);
+  });
+
+  it('returns school when found', async () => {
+    mockSchoolRepository.findById.mockResolvedValue(mockSchool);
+
+    const result = await useCase.execute('school-123');
+
+    expect(result).toEqual(mockSchool);
+    expect(mockSchoolRepository.findById).toHaveBeenCalledWith('school-123');
+  });
+
+  it('throws NotFoundException when school not found', async () => {
+    mockSchoolRepository.findById.mockResolvedValue(null);
+
+    await expect(useCase.execute('nonexistent')).rejects.toThrow(
+      NotFoundException,
+    );
+    expect(mockSchoolRepository.findById).toHaveBeenCalledWith('nonexistent');
+  });
+
+  it('throws NotFoundException with correct message', async () => {
+    mockSchoolRepository.findById.mockResolvedValue(null);
+
+    try {
+      await useCase.execute('school-999');
+      fail('Should have thrown NotFoundException');
+    } catch (error) {
+      expect(error).toBeInstanceOf(NotFoundException);
+      expect(error.message).toContain('School with ID school-999 not found');
+    }
+  });
+});

--- a/backend/src/domain/use-cases/get-school.use-case.ts
+++ b/backend/src/domain/use-cases/get-school.use-case.ts
@@ -1,0 +1,24 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import {
+  ISchoolRepository,
+  SCHOOL_REPOSITORY,
+} from '../repositories/school.repository.interface';
+import { School } from '../entities/school.entity';
+
+@Injectable()
+export class GetSchoolUseCase {
+  constructor(
+    @Inject(SCHOOL_REPOSITORY)
+    private readonly schoolRepository: ISchoolRepository,
+  ) {}
+
+  async execute(schoolId: string): Promise<School> {
+    const school = await this.schoolRepository.findById(schoolId);
+
+    if (!school) {
+      throw new NotFoundException(`School with ID ${schoolId} not found`);
+    }
+
+    return school;
+  }
+}

--- a/backend/src/presentation/admin/admin-schools.controller.spec.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.spec.ts
@@ -1,0 +1,206 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminSchoolsController } from './admin-schools.controller';
+import { ListSchoolsUseCase } from '../../domain/use-cases/list-schools.use-case';
+import { CreateSchoolUseCase } from '../../domain/use-cases/create-school.use-case';
+import { GetSchoolUseCase } from '../../domain/use-cases/get-school.use-case';
+import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
+import { GetSchoolStatsUseCase } from '../../domain/use-cases/get-school-stats.use-case';
+import { UpdateSchoolConfigUseCase } from '../../domain/use-cases/update-school-config.use-case';
+
+const mockSchool = {
+  id: 'school-123',
+  name: 'Test School',
+  lat: -23.5505,
+  lng: -46.6333,
+  geofenceRadiusMeters: 500,
+  notificationThresholdMeters: 1000,
+  createdAt: new Date(),
+};
+
+const mockArrivals = {
+  arrivals: [
+    {
+      parentId: 'parent-1',
+      parentName: 'John Doe',
+      lat: -23.5505,
+      lng: -46.6333,
+      distanceMeters: 1000,
+      etaMinutes: 10,
+      routePolyline: 'encoded_polyline',
+      calculatedAt: new Date(),
+    },
+  ],
+  schoolName: 'Test School',
+  totalCount: 1,
+};
+
+const mockStats = {
+  totalParents: 50,
+  avgETA: 12.5,
+  etaLessThan5Min: 10,
+  eta5To15Min: 25,
+  etaGreaterThan15Min: 15,
+};
+
+describe('AdminSchoolsController', () => {
+  let controller: AdminSchoolsController;
+  let listSchoolsUseCase: jest.Mocked<ListSchoolsUseCase>;
+  let createSchoolUseCase: jest.Mocked<CreateSchoolUseCase>;
+  let getSchoolUseCase: jest.Mocked<GetSchoolUseCase>;
+  let getSchoolArrivalsUseCase: jest.Mocked<GetSchoolArrivalsUseCase>;
+  let getSchoolStatsUseCase: jest.Mocked<GetSchoolStatsUseCase>;
+  let updateSchoolConfigUseCase: jest.Mocked<UpdateSchoolConfigUseCase>;
+
+  beforeEach(async () => {
+    const mockListSchoolsUseCase = {
+      execute: jest.fn(),
+    };
+    const mockCreateSchoolUseCase = {
+      execute: jest.fn(),
+    };
+    const mockGetSchoolUseCase = {
+      execute: jest.fn(),
+    };
+    const mockGetSchoolArrivalsUseCase = {
+      execute: jest.fn(),
+    };
+    const mockGetSchoolStatsUseCase = {
+      execute: jest.fn(),
+    };
+    const mockUpdateSchoolConfigUseCase = {
+      execute: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminSchoolsController],
+      providers: [
+        { provide: ListSchoolsUseCase, useValue: mockListSchoolsUseCase },
+        { provide: CreateSchoolUseCase, useValue: mockCreateSchoolUseCase },
+        { provide: GetSchoolUseCase, useValue: mockGetSchoolUseCase },
+        {
+          provide: GetSchoolArrivalsUseCase,
+          useValue: mockGetSchoolArrivalsUseCase,
+        },
+        { provide: GetSchoolStatsUseCase, useValue: mockGetSchoolStatsUseCase },
+        {
+          provide: UpdateSchoolConfigUseCase,
+          useValue: mockUpdateSchoolConfigUseCase,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AdminSchoolsController>(AdminSchoolsController);
+    listSchoolsUseCase = module.get(
+      ListSchoolsUseCase,
+    ) as jest.Mocked<ListSchoolsUseCase>;
+    createSchoolUseCase = module.get(
+      CreateSchoolUseCase,
+    ) as jest.Mocked<CreateSchoolUseCase>;
+    getSchoolUseCase = module.get(
+      GetSchoolUseCase,
+    ) as jest.Mocked<GetSchoolUseCase>;
+    getSchoolArrivalsUseCase = module.get(
+      GetSchoolArrivalsUseCase,
+    ) as jest.Mocked<GetSchoolArrivalsUseCase>;
+    getSchoolStatsUseCase = module.get(
+      GetSchoolStatsUseCase,
+    ) as jest.Mocked<GetSchoolStatsUseCase>;
+    updateSchoolConfigUseCase = module.get(
+      UpdateSchoolConfigUseCase,
+    ) as jest.Mocked<UpdateSchoolConfigUseCase>;
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should list all schools', async () => {
+    listSchoolsUseCase.execute.mockResolvedValue({ schools: [mockSchool] });
+
+    const result = await controller.listSchools();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('school-123');
+    expect(result[0].name).toBe('Test School');
+    expect(listSchoolsUseCase.execute).toHaveBeenCalled();
+  });
+
+  it('should create a school', async () => {
+    createSchoolUseCase.execute.mockResolvedValue(mockSchool);
+
+    const createDto = {
+      name: 'Test School',
+      lat: -23.5505,
+      lng: -46.6333,
+      geofenceRadiusMeters: 500,
+      notificationThresholdMeters: 1000,
+    };
+
+    const result = await controller.createSchool(createDto);
+
+    expect(result.id).toBe('school-123');
+    expect(result.name).toBe('Test School');
+    expect(createSchoolUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining(createDto),
+    );
+  });
+
+  it('should get school detail', async () => {
+    getSchoolUseCase.execute.mockResolvedValue(mockSchool);
+
+    const result = await controller.getSchool('school-123');
+
+    expect(result.id).toBe('school-123');
+    expect(getSchoolUseCase.execute).toHaveBeenCalledWith('school-123');
+  });
+
+  it('should get school arrivals', async () => {
+    getSchoolArrivalsUseCase.execute.mockResolvedValue(mockArrivals);
+
+    const result = await controller.getArrivals('school-123');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parentId).toBe('parent-1');
+    expect(getSchoolArrivalsUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ schoolId: 'school-123' }),
+    );
+  });
+
+  it('should get school stats', async () => {
+    getSchoolStatsUseCase.execute.mockResolvedValue(mockStats);
+
+    const result = await controller.getStats('school-123');
+
+    expect(result.totalParents).toBe(50);
+    expect(result.avgETA).toBe(12.5);
+    expect(getSchoolStatsUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ schoolId: 'school-123' }),
+    );
+  });
+
+  it('should update school config', async () => {
+    const configResult = {
+      id: 'school-123',
+      name: 'Test School',
+      geofenceRadiusMeters: 600,
+      notificationThresholdMeters: 1200,
+      updatedAt: new Date(),
+    };
+    updateSchoolConfigUseCase.execute.mockResolvedValue(configResult);
+
+    const configDto = {
+      geofenceRadiusMeters: 600,
+      notificationThresholdMeters: 1200,
+    };
+
+    const result = await controller.updateConfig('school-123', configDto);
+
+    expect(result.geofenceRadiusMeters).toBe(600);
+    expect(updateSchoolConfigUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schoolId: 'school-123',
+        ...configDto,
+      }),
+    );
+  });
+});

--- a/backend/src/presentation/admin/admin-schools.controller.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.ts
@@ -1,0 +1,183 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { AdminJwtAuthGuard } from '../../infrastructure/auth/admin-jwt-auth.guard';
+import { RolesGuard } from '../../infrastructure/auth/roles.guard';
+import { SchoolAccessGuard } from '../../infrastructure/auth/school-access.guard';
+import { Roles } from '../../infrastructure/auth/roles.decorator';
+import { ListSchoolsUseCase } from '../../domain/use-cases/list-schools.use-case';
+import {
+  CreateSchoolUseCase,
+  CreateSchoolInput,
+} from '../../domain/use-cases/create-school.use-case';
+import { GetSchoolUseCase } from '../../domain/use-cases/get-school.use-case';
+import {
+  GetSchoolArrivalsUseCase,
+  GetSchoolArrivalsInput,
+} from '../../domain/use-cases/get-school-arrivals.use-case';
+import {
+  GetSchoolStatsUseCase,
+  GetSchoolStatsInput,
+} from '../../domain/use-cases/get-school-stats.use-case';
+import {
+  UpdateSchoolConfigUseCase,
+  UpdateSchoolConfigInput,
+} from '../../domain/use-cases/update-school-config.use-case';
+import { ArrivalDto } from '../schools/dtos/arrival.dto';
+import {
+  SchoolStatsDto,
+  SchoolConfigDto,
+} from '../schools/dtos/school-config.dto';
+import { CreateSchoolDto } from '../schools/dtos/create-school.dto';
+import {
+  SchoolResponseDto,
+  SchoolListResponseDto,
+} from '../schools/dtos/school-response.dto';
+
+@ApiTags('admin/schools')
+@Controller('admin/schools')
+@UseGuards(AdminJwtAuthGuard, RolesGuard)
+@ApiBearerAuth('admin-jwt')
+export class AdminSchoolsController {
+  constructor(
+    private readonly listSchoolsUseCase: ListSchoolsUseCase,
+    private readonly createSchoolUseCase: CreateSchoolUseCase,
+    private readonly getSchoolUseCase: GetSchoolUseCase,
+    private readonly getSchoolArrivalsUseCase: GetSchoolArrivalsUseCase,
+    private readonly getSchoolStatsUseCase: GetSchoolStatsUseCase,
+    private readonly updateSchoolConfigUseCase: UpdateSchoolConfigUseCase,
+  ) {}
+
+  @Get()
+  @Roles('super_admin')
+  async listSchools(): Promise<SchoolListResponseDto[]> {
+    const result = await this.listSchoolsUseCase.execute();
+
+    return result.schools.map((school) => ({
+      id: school.id,
+      name: school.name,
+      location: {
+        lat: school.lat,
+        lng: school.lng,
+      },
+      geofenceRadiusMeters: school.geofenceRadiusMeters,
+      notificationThresholdMeters: school.notificationThresholdMeters,
+    }));
+  }
+
+  @Post()
+  @Roles('super_admin')
+  @HttpCode(HttpStatus.CREATED)
+  async createSchool(
+    @Body() createSchoolDto: CreateSchoolDto,
+  ): Promise<SchoolResponseDto> {
+    const input: CreateSchoolInput = {
+      name: createSchoolDto.name,
+      lat: createSchoolDto.lat,
+      lng: createSchoolDto.lng,
+      geofenceRadiusMeters: createSchoolDto.geofenceRadiusMeters,
+      notificationThresholdMeters: createSchoolDto.notificationThresholdMeters,
+    };
+
+    const result = await this.createSchoolUseCase.execute(input);
+
+    return {
+      id: result.id,
+      name: result.name,
+      lat: result.lat,
+      lng: result.lng,
+      geofenceRadiusMeters: result.geofenceRadiusMeters,
+      notificationThresholdMeters: result.notificationThresholdMeters,
+      createdAt: result.createdAt,
+    };
+  }
+
+  @Get(':schoolId')
+  @Roles('super_admin', 'school_admin')
+  @UseGuards(SchoolAccessGuard)
+  async getSchool(
+    @Param('schoolId') schoolId: string,
+  ): Promise<SchoolListResponseDto> {
+    const school = await this.getSchoolUseCase.execute(schoolId);
+
+    return {
+      id: school.id,
+      name: school.name,
+      location: {
+        lat: school.lat,
+        lng: school.lng,
+      },
+      geofenceRadiusMeters: school.geofenceRadiusMeters,
+      notificationThresholdMeters: school.notificationThresholdMeters,
+    };
+  }
+
+  @Get(':schoolId/arrivals')
+  @Roles('super_admin', 'school_admin')
+  @UseGuards(SchoolAccessGuard)
+  async getArrivals(
+    @Param('schoolId') schoolId: string,
+    @Query('limit') limit?: number,
+  ): Promise<ArrivalDto[]> {
+    const input: GetSchoolArrivalsInput = {
+      schoolId,
+      limit: limit ? parseInt(limit.toString(), 10) : undefined,
+    };
+
+    const result = await this.getSchoolArrivalsUseCase.execute(input);
+
+    return result.arrivals.map((arrival) => ({
+      parentId: arrival.parentId,
+      distanceMeters: arrival.distanceMeters,
+      durationMinutes: arrival.etaMinutes,
+      routePolyline: arrival.routePolyline,
+    }));
+  }
+
+  @Get(':schoolId/stats')
+  @Roles('super_admin', 'school_admin')
+  @UseGuards(SchoolAccessGuard)
+  async getStats(@Param('schoolId') schoolId: string): Promise<SchoolStatsDto> {
+    const input: GetSchoolStatsInput = { schoolId };
+    const result = await this.getSchoolStatsUseCase.execute(input);
+
+    return {
+      totalParents: result.totalParents,
+      avgETA: result.avgETA,
+      etaLessThan5Min: result.etaLessThan5Min,
+      eta5To15Min: result.eta5To15Min,
+      etaGreaterThan15Min: result.etaGreaterThan15Min,
+    };
+  }
+
+  @Post(':schoolId/config')
+  @Roles('super_admin', 'school_admin')
+  @UseGuards(SchoolAccessGuard)
+  @HttpCode(HttpStatus.OK)
+  async updateConfig(
+    @Param('schoolId') schoolId: string,
+    @Body() configDto: SchoolConfigDto,
+  ): Promise<SchoolConfigDto> {
+    const input: UpdateSchoolConfigInput = {
+      schoolId,
+      geofenceRadiusMeters: configDto.geofenceRadiusMeters,
+      notificationThresholdMeters: configDto.notificationThresholdMeters,
+    };
+
+    const result = await this.updateSchoolConfigUseCase.execute(input);
+
+    return {
+      geofenceRadiusMeters: result.geofenceRadiusMeters,
+      notificationThresholdMeters: result.notificationThresholdMeters,
+    };
+  }
+}

--- a/backend/src/presentation/admin/admin.module.ts
+++ b/backend/src/presentation/admin/admin.module.ts
@@ -4,9 +4,16 @@ import { PassportModule } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 import { DataModule } from '@data/data.module';
 import { AdminAuthController } from './admin-auth.controller';
+import { AdminSchoolsController } from './admin-schools.controller';
 import { AdminAuthService } from './admin-auth.service';
 import { AdminJwtStrategy } from '@infrastructure/auth/admin-jwt.strategy';
 import { parseJwtExpiresIn } from '@infrastructure/auth/jwt.constants';
+import { ListSchoolsUseCase } from '@domain/use-cases/list-schools.use-case';
+import { CreateSchoolUseCase } from '@domain/use-cases/create-school.use-case';
+import { GetSchoolUseCase } from '@domain/use-cases/get-school.use-case';
+import { GetSchoolArrivalsUseCase } from '@domain/use-cases/get-school-arrivals.use-case';
+import { GetSchoolStatsUseCase } from '@domain/use-cases/get-school-stats.use-case';
+import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-config.use-case';
 
 @Module({
   imports: [
@@ -24,8 +31,17 @@ import { parseJwtExpiresIn } from '@infrastructure/auth/jwt.constants';
       }),
     }),
   ],
-  controllers: [AdminAuthController],
-  providers: [AdminAuthService, AdminJwtStrategy],
+  controllers: [AdminAuthController, AdminSchoolsController],
+  providers: [
+    AdminAuthService,
+    AdminJwtStrategy,
+    ListSchoolsUseCase,
+    CreateSchoolUseCase,
+    GetSchoolUseCase,
+    GetSchoolArrivalsUseCase,
+    GetSchoolStatsUseCase,
+    UpdateSchoolConfigUseCase,
+  ],
   exports: [AdminAuthService],
 })
 export class AdminModule {}


### PR DESCRIPTION
## Summary
Implement invite code system for schools (Phase 4 of onMyWay). Parents can register using 8-character uppercase alphanumeric invite codes. Admins can view and regenerate codes.

**Endpoints added:**
- `GET /admin/schools/:schoolId/invite` — retrieve current invite code
- `POST /admin/schools/:schoolId/regenerate-invite` — generate new invite code
- `POST /auth/register` — accept optional `inviteCode` parameter to resolve schoolId

**Changes:**
- School entity: add `inviteCode: string` field
- Database migration: add `invite_code VARCHAR(8) UNIQUE` column
- Two new use cases: GetSchoolInviteUseCase, RegenerateSchoolInviteUseCase
- AuthService: resolve inviteCode → schoolId during parent registration
- Admin endpoints with proper authorization (super_admin + school_admin)

## Test plan
- [x] All 193 unit tests pass (9 new tests for invite code)
- [x] ESLint passes with 0 warnings
- [x] TypeScript compiles without errors
- [x] GetSchoolInviteUseCase: 2 tests (found, not found)
- [x] RegenerateSchoolInviteUseCase: 2 tests (regenerate, not found)
- [x] AdminSchoolsController: 2 new endpoint tests
- [x] AuthService: inviteCode resolution tests
- [x] All existing tests updated with inviteCode in mocks
- [x] Three commits: domain/data, use cases/presentation, tests

