### PR TITLE
ci: add mobile CI workflow

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,150 @@
+name: Mobile CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - "mobile/**"
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run security audit
+        run: npm audit --audit-level=high --omit=dev
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [audit]
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Mobile CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });
+
+  typecheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    needs: [audit]
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npx tsc --noEmit
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Mobile CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck]
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Comment on PR if failed
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const run_url = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const job = '${{ github.job }}';
+            await github.rest.issues.createComment({
+              owner, repo,
+              issue_number: context.issue.number,
+              body: `## ❌ Mobile CI — \`${job}\` falhou\n\n[Ver logs completos](${run_url})\n\nO Developer deve verificar os logs e corrigir.`,
+            });

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-      - main
     paths:
       - "mobile/**"
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/mobile-ci.yml` for PRs touching `mobile/**`
- Pipeline: **audit** (high) → **lint + typecheck** (parallel) → **tests**
- No PostgreSQL service needed (mobile has no DB dependency)
- Failed jobs comment on PR with link to logs, mirroring `backend-ci.yml`

## Test plan

- [ ] Open a PR targeting `develop` with changes under `mobile/` — workflow should trigger
- [ ] Introduce a lint error → `lint` job should fail and comment on PR
- [ ] Introduce a type error → `typecheck` job should fail and comment on PR
- [ ] Make a test fail → `tests` job should fail and comment on PR
- [ ] All green → PR shows CI passing

Closes #216