### PR TITLE
feat(web): school-admin invite code + parent management pages

### DIFF
--- a/backend/src/domain/use-cases/list-school-parents.use-case.spec.ts
+++ b/backend/src/domain/use-cases/list-school-parents.use-case.spec.ts
@@ -78,7 +78,9 @@ describe('ListSchoolParentsUseCase', () => {
     expect(result.parents[0].name).toBe('John Doe');
     expect(result.parents[1].name).toBe('Jane Smith');
     expect(schoolRepositoryMock.findById).toHaveBeenCalledWith('school-1');
-    expect(parentRepositoryMock.findBySchoolId).toHaveBeenCalledWith('school-1');
+    expect(parentRepositoryMock.findBySchoolId).toHaveBeenCalledWith(
+      'school-1',
+    );
   });
 
   it('should return empty array when no parents registered', async () => {
@@ -93,7 +95,9 @@ describe('ListSchoolParentsUseCase', () => {
   it('should throw NotFoundException when school does not exist', async () => {
     schoolRepositoryMock.findById.mockResolvedValue(null);
 
-    await expect(useCase.execute('nonexistent')).rejects.toThrow(NotFoundException);
+    await expect(useCase.execute('nonexistent')).rejects.toThrow(
+      NotFoundException,
+    );
     expect(parentRepositoryMock.findBySchoolId).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/domain/use-cases/list-school-parents.use-case.spec.ts
+++ b/backend/src/domain/use-cases/list-school-parents.use-case.spec.ts
@@ -1,0 +1,99 @@
+import { NotFoundException } from '@nestjs/common';
+import { ListSchoolParentsUseCase } from './list-school-parents.use-case';
+import { ISchoolRepository } from '../repositories/school.repository.interface';
+import { IParentRepository } from '../repositories/parent.repository.interface';
+import { School } from '../entities/school.entity';
+import { Parent } from '../entities/parent.entity';
+
+describe('ListSchoolParentsUseCase', () => {
+  let useCase: ListSchoolParentsUseCase;
+  let schoolRepositoryMock: jest.Mocked<ISchoolRepository>;
+  let parentRepositoryMock: jest.Mocked<IParentRepository>;
+
+  const mockSchool: School = {
+    id: 'school-1',
+    name: 'Springfield Elementary',
+    lat: -23.55052,
+    lng: -46.633308,
+    geofenceRadiusMeters: 500,
+    notificationThresholdMeters: 1000,
+    inviteCode: 'AB3X7Y2Z',
+    createdAt: new Date(),
+  };
+
+  const mockParents: Parent[] = [
+    {
+      id: 'parent-1',
+      name: 'John Doe',
+      email: 'john@example.com',
+      phone: '11999999999',
+      schoolId: 'school-1',
+      createdAt: new Date(),
+    },
+    {
+      id: 'parent-2',
+      name: 'Jane Smith',
+      email: 'jane@example.com',
+      phone: '11988888888',
+      schoolId: 'school-1',
+      createdAt: new Date(),
+    },
+  ];
+
+  beforeEach(() => {
+    schoolRepositoryMock = {
+      findById: jest.fn(),
+      findByInviteCode: jest.fn(),
+      findAll: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findParentsWithinGeofence: jest.fn(),
+    };
+
+    parentRepositoryMock = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findBySchoolId: jest.fn(),
+      findByIds: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      validateCredentials: jest.fn(),
+    };
+
+    useCase = new ListSchoolParentsUseCase(
+      schoolRepositoryMock,
+      parentRepositoryMock,
+    );
+  });
+
+  it('should return parents for a valid school', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    parentRepositoryMock.findBySchoolId.mockResolvedValue(mockParents);
+
+    const result = await useCase.execute('school-1');
+
+    expect(result.parents).toHaveLength(2);
+    expect(result.parents[0].name).toBe('John Doe');
+    expect(result.parents[1].name).toBe('Jane Smith');
+    expect(schoolRepositoryMock.findById).toHaveBeenCalledWith('school-1');
+    expect(parentRepositoryMock.findBySchoolId).toHaveBeenCalledWith('school-1');
+  });
+
+  it('should return empty array when no parents registered', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    parentRepositoryMock.findBySchoolId.mockResolvedValue([]);
+
+    const result = await useCase.execute('school-1');
+
+    expect(result.parents).toHaveLength(0);
+  });
+
+  it('should throw NotFoundException when school does not exist', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(null);
+
+    await expect(useCase.execute('nonexistent')).rejects.toThrow(NotFoundException);
+    expect(parentRepositoryMock.findBySchoolId).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domain/use-cases/list-school-parents.use-case.ts
+++ b/backend/src/domain/use-cases/list-school-parents.use-case.ts
@@ -1,0 +1,36 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import {
+  ISchoolRepository,
+  SCHOOL_REPOSITORY,
+} from '../repositories/school.repository.interface';
+import {
+  IParentRepository,
+  PARENT_REPOSITORY,
+} from '../repositories/parent.repository.interface';
+import { Parent } from '../entities/parent.entity';
+
+export interface ListSchoolParentsOutput {
+  parents: Parent[];
+}
+
+@Injectable()
+export class ListSchoolParentsUseCase {
+  constructor(
+    @Inject(SCHOOL_REPOSITORY)
+    private readonly schoolRepository: ISchoolRepository,
+    @Inject(PARENT_REPOSITORY)
+    private readonly parentRepository: IParentRepository,
+  ) {}
+
+  async execute(schoolId: string): Promise<ListSchoolParentsOutput> {
+    const school = await this.schoolRepository.findById(schoolId);
+
+    if (!school) {
+      throw new NotFoundException(`School with ID ${schoolId} not found`);
+    }
+
+    const parents = await this.parentRepository.findBySchoolId(schoolId);
+
+    return { parents };
+  }
+}

--- a/backend/src/presentation/admin/admin-schools.controller.spec.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.spec.ts
@@ -5,6 +5,7 @@ import { CreateSchoolUseCase } from '../../domain/use-cases/create-school.use-ca
 import { GetSchoolUseCase } from '../../domain/use-cases/get-school.use-case';
 import { GetSchoolInviteUseCase } from '../../domain/use-cases/get-school-invite.use-case';
 import { RegenerateSchoolInviteUseCase } from '../../domain/use-cases/regenerate-school-invite.use-case';
+import { ListSchoolParentsUseCase } from '../../domain/use-cases/list-school-parents.use-case';
 import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
 import { GetSchoolStatsUseCase } from '../../domain/use-cases/get-school-stats.use-case';
 import { UpdateSchoolConfigUseCase } from '../../domain/use-cases/update-school-config.use-case';
@@ -70,6 +71,9 @@ describe('AdminSchoolsController', () => {
     const mockRegenerateSchoolInviteUseCase = {
       execute: jest.fn(),
     };
+    const mockListSchoolParentsUseCase = {
+      execute: jest.fn(),
+    };
     const mockGetSchoolArrivalsUseCase = {
       execute: jest.fn(),
     };
@@ -93,6 +97,10 @@ describe('AdminSchoolsController', () => {
         {
           provide: RegenerateSchoolInviteUseCase,
           useValue: mockRegenerateSchoolInviteUseCase,
+        },
+        {
+          provide: ListSchoolParentsUseCase,
+          useValue: mockListSchoolParentsUseCase,
         },
         {
           provide: GetSchoolArrivalsUseCase,

--- a/backend/src/presentation/admin/admin-schools.controller.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.ts
@@ -22,6 +22,7 @@ import {
 import { GetSchoolUseCase } from '../../domain/use-cases/get-school.use-case';
 import { GetSchoolInviteUseCase } from '../../domain/use-cases/get-school-invite.use-case';
 import { RegenerateSchoolInviteUseCase } from '../../domain/use-cases/regenerate-school-invite.use-case';
+import { ListSchoolParentsUseCase } from '../../domain/use-cases/list-school-parents.use-case';
 import {
   GetSchoolArrivalsUseCase,
   GetSchoolArrivalsInput,
@@ -56,6 +57,7 @@ export class AdminSchoolsController {
     private readonly getSchoolUseCase: GetSchoolUseCase,
     private readonly getSchoolInviteUseCase: GetSchoolInviteUseCase,
     private readonly regenerateSchoolInviteUseCase: RegenerateSchoolInviteUseCase,
+    private readonly listSchoolParentsUseCase: ListSchoolParentsUseCase,
     private readonly getSchoolArrivalsUseCase: GetSchoolArrivalsUseCase,
     private readonly getSchoolStatsUseCase: GetSchoolStatsUseCase,
     private readonly updateSchoolConfigUseCase: UpdateSchoolConfigUseCase,
@@ -210,5 +212,22 @@ export class AdminSchoolsController {
     return {
       inviteCode: result.inviteCode,
     };
+  }
+
+  @Get(':schoolId/parents')
+  @Roles('super_admin', 'school_admin')
+  @UseGuards(SchoolAccessGuard)
+  async listParents(
+    @Param('schoolId') schoolId: string,
+  ): Promise<{ id: string; name: string; email: string; phone: string; createdAt: Date }[]> {
+    const result = await this.listSchoolParentsUseCase.execute(schoolId);
+
+    return result.parents.map((parent) => ({
+      id: parent.id,
+      name: parent.name,
+      email: parent.email,
+      phone: parent.phone,
+      createdAt: parent.createdAt,
+    }));
   }
 }

--- a/backend/src/presentation/admin/admin-schools.controller.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.ts
@@ -217,9 +217,15 @@ export class AdminSchoolsController {
   @Get(':schoolId/parents')
   @Roles('super_admin', 'school_admin')
   @UseGuards(SchoolAccessGuard)
-  async listParents(
-    @Param('schoolId') schoolId: string,
-  ): Promise<{ id: string; name: string; email: string; phone: string; createdAt: Date }[]> {
+  async listParents(@Param('schoolId') schoolId: string): Promise<
+    {
+      id: string;
+      name: string;
+      email: string;
+      phone: string;
+      createdAt: Date;
+    }[]
+  > {
     const result = await this.listSchoolParentsUseCase.execute(schoolId);
 
     return result.parents.map((parent) => ({

--- a/backend/src/presentation/admin/admin.module.ts
+++ b/backend/src/presentation/admin/admin.module.ts
@@ -13,6 +13,7 @@ import { CreateSchoolUseCase } from '@domain/use-cases/create-school.use-case';
 import { GetSchoolUseCase } from '@domain/use-cases/get-school.use-case';
 import { GetSchoolInviteUseCase } from '@domain/use-cases/get-school-invite.use-case';
 import { RegenerateSchoolInviteUseCase } from '@domain/use-cases/regenerate-school-invite.use-case';
+import { ListSchoolParentsUseCase } from '@domain/use-cases/list-school-parents.use-case';
 import { GetSchoolArrivalsUseCase } from '@domain/use-cases/get-school-arrivals.use-case';
 import { GetSchoolStatsUseCase } from '@domain/use-cases/get-school-stats.use-case';
 import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-config.use-case';
@@ -42,6 +43,7 @@ import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-confi
     GetSchoolUseCase,
     GetSchoolInviteUseCase,
     RegenerateSchoolInviteUseCase,
+    ListSchoolParentsUseCase,
     GetSchoolArrivalsUseCase,
     GetSchoolStatsUseCase,
     UpdateSchoolConfigUseCase,

--- a/web/src/app/actions/regenerate-invite.action.ts
+++ b/web/src/app/actions/regenerate-invite.action.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { TOKEN_KEY } from '@/lib/auth';
+import { regenerateSchoolInvite } from '@/lib/server-api';
+
+export async function regenerateInviteAction(
+  schoolId: string,
+): Promise<{ success: boolean; inviteCode?: string; error?: string }> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get(TOKEN_KEY)?.value;
+
+    if (!token) {
+      return { success: false, error: 'Não autenticado' };
+    }
+
+    const result = await regenerateSchoolInvite(schoolId, token);
+    return { success: true, inviteCode: result.inviteCode };
+  } catch (error) {
+    console.error('Error regenerating invite code:', error);
+    return { success: false, error: 'Erro ao regenerar código. Tente novamente.' };
+  }
+}

--- a/web/src/app/dashboard/[schoolId]/invite/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/invite/page.tsx
@@ -1,0 +1,35 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { TOKEN_KEY } from '@/lib/auth';
+import { getSchoolInvite } from '@/lib/server-api';
+import { InviteCodeCard } from '@/components/invite/InviteCodeCard';
+
+interface InvitePageProps {
+  params: Promise<{ schoolId: string }>;
+}
+
+export default async function InvitePage({ params }: InvitePageProps) {
+  const { schoolId } = await params;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_KEY)?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  const { inviteCode } = await getSchoolInvite(schoolId, token);
+
+  return (
+    <div className="p-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Código de Convite</h1>
+        <p className="text-gray-600 mt-2">
+          Gerencie o código que permite novos pais se cadastrarem nesta escola
+        </p>
+      </div>
+
+      <InviteCodeCard schoolId={schoolId} initialInviteCode={inviteCode} />
+    </div>
+  );
+}

--- a/web/src/app/dashboard/[schoolId]/parents/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/parents/page.tsx
@@ -1,0 +1,81 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { TOKEN_KEY } from '@/lib/auth';
+import { getSchoolParents } from '@/lib/server-api';
+
+interface ParentsPageProps {
+  params: Promise<{ schoolId: string }>;
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+export default async function ParentsPage({ params }: ParentsPageProps) {
+  const { schoolId } = await params;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_KEY)?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  const parents = await getSchoolParents(schoolId, token).catch(() => []);
+
+  return (
+    <div className="p-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Pais Cadastrados</h1>
+        <p className="text-gray-600 mt-2">
+          {parents.length} {parents.length === 1 ? 'pai cadastrado' : 'pais cadastrados'} nesta
+          escola
+        </p>
+      </div>
+
+      {parents.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
+          <p className="text-gray-400 text-lg">Nenhum pai cadastrado ainda.</p>
+          <p className="text-gray-400 text-sm mt-1">
+            Compartilhe o código de convite para que pais possam se registrar.
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-200 bg-gray-50">
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Nome
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Email
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Telefone
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Cadastrado em
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {parents.map((parent) => (
+                <tr key={parent.id} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-6 py-4 text-sm font-medium text-gray-900">{parent.name}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{parent.email}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">{parent.phone}</td>
+                  <td className="px-6 py-4 text-sm text-gray-500">{formatDate(parent.createdAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/invite/InviteCodeCard.tsx
+++ b/web/src/components/invite/InviteCodeCard.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { regenerateInviteAction } from '@/app/actions/regenerate-invite.action';
+
+interface InviteCodeCardProps {
+  schoolId: string;
+  initialInviteCode: string;
+}
+
+export function InviteCodeCard({ schoolId, initialInviteCode }: InviteCodeCardProps) {
+  const [inviteCode, setInviteCode] = useState(initialInviteCode);
+  const [copied, setCopied] = useState(false);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(inviteCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleRegenerate = async () => {
+    setIsRegenerating(true);
+    setError(null);
+
+    const result = await regenerateInviteAction(schoolId);
+
+    if (result.success && result.inviteCode) {
+      setInviteCode(result.inviteCode);
+    } else {
+      setError(result.error ?? 'Erro desconhecido');
+    }
+
+    setIsRegenerating(false);
+  };
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-6 max-w-md">
+      <div className="mb-4">
+        <p className="text-sm text-gray-500 mb-2">Código de convite</p>
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-3xl font-bold tracking-widest text-gray-900">
+            {inviteCode}
+          </span>
+          <button
+            onClick={handleCopy}
+            className="p-2 rounded-lg bg-gray-100 hover:bg-gray-200 transition-colors text-gray-600"
+            title="Copiar código"
+          >
+            {copied ? '✓' : '⎘'}
+          </button>
+        </div>
+        {copied && <p className="text-sm text-green-600 mt-1">Copiado!</p>}
+      </div>
+
+      <p className="text-sm text-gray-500 mb-4">
+        Compartilhe este código com os pais para que eles possam se cadastrar e
+        vincular à sua escola.
+      </p>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <button
+        onClick={handleRegenerate}
+        disabled={isRegenerating}
+        className="w-full px-4 py-2 bg-red-50 text-red-700 border border-red-200 rounded-lg hover:bg-red-100 transition-colors font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isRegenerating ? 'Regenerando...' : 'Regenerar código'}
+      </button>
+
+      <p className="text-xs text-gray-400 mt-2 text-center">
+        Atenção: regenerar invalida o código atual.
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/layout/DashboardSidebar.tsx
+++ b/web/src/components/layout/DashboardSidebar.tsx
@@ -22,6 +22,16 @@ export function DashboardSidebar({
       icon: '🚗',
     },
     {
+      href: `/dashboard/${schoolId}/parents`,
+      label: 'Pais',
+      icon: '👥',
+    },
+    {
+      href: `/dashboard/${schoolId}/invite`,
+      label: 'Código de Convite',
+      icon: '🔑',
+    },
+    {
       href: `/dashboard/${schoolId}/settings`,
       label: 'Configurações',
       icon: '⚙️',

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,4 +1,4 @@
-import { Arrival, School, SchoolStats, SchoolConfig } from '@/types';
+import { Arrival, School, SchoolStats, SchoolConfig, SchoolParent } from '@/types';
 
 export class UnauthorizedError extends Error {
   constructor() {
@@ -84,4 +84,32 @@ export async function createSchool(
     method: 'POST',
     body: JSON.stringify(data),
   });
+}
+
+export async function getSchoolInvite(
+  schoolId: string,
+  token: string,
+): Promise<{ inviteCode: string }> {
+  return serverFetch<{ inviteCode: string }>(
+    `/admin/schools/${schoolId}/invite`,
+    token,
+  );
+}
+
+export async function regenerateSchoolInvite(
+  schoolId: string,
+  token: string,
+): Promise<{ inviteCode: string }> {
+  return serverFetch<{ inviteCode: string }>(
+    `/admin/schools/${schoolId}/regenerate-invite`,
+    token,
+    { method: 'POST' },
+  );
+}
+
+export async function getSchoolParents(
+  schoolId: string,
+  token: string,
+): Promise<SchoolParent[]> {
+  return serverFetch<SchoolParent[]>(`/admin/schools/${schoolId}/parents`, token);
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -43,3 +43,11 @@ export interface SchoolConfig {
   geofenceRadiusMeters: number;
   notificationThresholdMeters: number;
 }
+
+export interface SchoolParent {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

- **Backend**: `ListSchoolParentsUseCase` + `GET /admin/schools/:schoolId/parents` endpoint
- **Web**: Invite code page with copy/regenerate, parents list page, sidebar links updated

### Pages added
- `/dashboard/[schoolId]/invite` — shows 8-char invite code, copy button, regenerate (with warning)
- `/dashboard/[schoolId]/parents` — SSR table listing name, email, phone, join date

### Components
- `InviteCodeCard` (client) — copy to clipboard, calls `regenerateInviteAction` server action

### Other changes
- `DashboardSidebar`: added "Pais" and "Código de Convite" links
- `server-api`: `getSchoolInvite`, `regenerateSchoolInvite`, `getSchoolParents`
- `types`: `SchoolParent` interface

## Test plan

### Pré-condições
- Usuário autenticado como `school_admin` com `schoolId` válido
- Escola com pelo menos 1 pai cadastrado (para testar lista preenchida)
- Escola sem pais cadastrados (para testar estado vazio)

### Página `/dashboard/:schoolId/invite`

- [x] Acessa a página → código de 8 caracteres é exibido corretamente
- [x] Clica em copiar → texto "Copiado!" aparece brevemente e o código está no clipboard
- [x] Clica em "Regenerar código" → novo código diferente é exibido
- [x] Após regenerar, o código antigo não é mais aceito no `POST /auth/register`
- [x] O novo código gerado é aceito no `POST /auth/register`
- [x] Acessa sem token → redireciona para `/login`

### Página `/dashboard/:schoolId/parents`

- [x] Escola com pais → tabela exibe nome, email, telefone e data de cadastro
- [x] Escola sem pais → estado vazio exibido com orientação para usar o código de convite
- [x] Contador no subtítulo reflete a quantidade correta de pais
- [x] Acessa sem token → redireciona para `/login`

### Sidebar

- [x] Link "Pais" aparece no menu lateral e navega para `/dashboard/:id/parents`
- [x] Link "Código de Convite" aparece no menu lateral e navega para `/dashboard/:id/invite`
- [x] Link ativo é destacado corretamente (fundo azul)

### Backend — `GET /admin/schools/:schoolId/parents`

- [x] Retorna lista de pais com `id`, `name`, `email`, `phone`, `createdAt`
- [x] Retorna `404` quando `schoolId` não existe
- [x] Retorna `401` sem token
- [x] `school_admin` só acessa sua própria escola (SchoolAccessGuard bloqueia outro schoolId)

Closes #240