### PR TITLE
feat(backend): CRUD school admin users

### DIFF
--- a/backend/src/data/repositories/user.repository.spec.ts
+++ b/backend/src/data/repositories/user.repository.spec.ts
@@ -21,8 +21,10 @@ describe('UserRepository', () => {
           provide: getRepositoryToken(UserModel),
           useValue: {
             findOne: jest.fn(),
+            find: jest.fn(),
             create: jest.fn(),
             save: jest.fn(),
+            delete: jest.fn(),
           },
         },
       ],
@@ -250,6 +252,80 @@ describe('UserRepository', () => {
       });
       expect(bcrypt.compare).toHaveBeenCalledWith(password, 'hashed-password');
       expect(UserMapper.toDomain).toHaveBeenCalledWith(mockModel);
+    });
+  });
+
+  describe('findBySchoolId', () => {
+    it('should return empty array when no users found for school', async () => {
+      const schoolId = 'school-123';
+      jest.spyOn(userRepositoryMock, 'find').mockResolvedValue([]);
+
+      const result = await repository.findBySchoolId(schoolId);
+
+      expect(result).toEqual([]);
+      expect(userRepositoryMock.find).toHaveBeenCalledWith({
+        where: { schoolId },
+      });
+    });
+
+    it('should return mapped domain entities for existing school admins', async () => {
+      const schoolId = 'school-123';
+      const mockModels: UserModel[] = [
+        {
+          id: 'user-1',
+          name: 'Admin One',
+          email: 'admin1@school.com',
+          role: 'school_admin',
+          schoolId,
+          passwordHash: 'hash1',
+          createdAt: new Date(),
+        },
+        {
+          id: 'user-2',
+          name: 'Admin Two',
+          email: 'admin2@school.com',
+          role: 'school_admin',
+          schoolId,
+          passwordHash: 'hash2',
+          createdAt: new Date(),
+        },
+      ];
+
+      const expectedEntities: User[] = mockModels.map((m) => ({
+        id: m.id,
+        name: m.name,
+        email: m.email,
+        role: m.role,
+        schoolId: m.schoolId,
+        createdAt: m.createdAt,
+      }));
+
+      jest.spyOn(userRepositoryMock, 'find').mockResolvedValue(mockModels);
+      jest
+        .spyOn(UserMapper, 'toDomain')
+        .mockReturnValueOnce(expectedEntities[0])
+        .mockReturnValueOnce(expectedEntities[1]);
+
+      const result = await repository.findBySchoolId(schoolId);
+
+      expect(result).toEqual(expectedEntities);
+      expect(userRepositoryMock.find).toHaveBeenCalledWith({
+        where: { schoolId },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('should call delete on the TypeORM repository', async () => {
+      const userId = 'user-456';
+      jest.spyOn(userRepositoryMock, 'delete').mockResolvedValue({
+        affected: 1,
+        raw: {},
+      });
+
+      await repository.delete(userId);
+
+      expect(userRepositoryMock.delete).toHaveBeenCalledWith(userId);
     });
   });
 });

--- a/backend/src/data/repositories/user.repository.ts
+++ b/backend/src/data/repositories/user.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, DeleteResult } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { UserModel } from '../models/user.model';
 import { UserMapper } from '../mappers/user.mapper';
@@ -24,6 +24,11 @@ export class UserRepository implements IUserRepository {
     return model ? UserMapper.toDomain(model) : null;
   }
 
+  async findBySchoolId(schoolId: string): Promise<User[]> {
+    const models = await this.userRepository.find({ where: { schoolId } });
+    return models.map((model) => UserMapper.toDomain(model));
+  }
+
   async create(
     data: Omit<User, 'id' | 'createdAt'> & { passwordHash: string },
   ): Promise<User> {
@@ -31,6 +36,10 @@ export class UserRepository implements IUserRepository {
     const model = this.userRepository.create(modelData);
     const savedModel = await this.userRepository.save(model);
     return UserMapper.toDomain(savedModel);
+  }
+
+  async delete(id: string): Promise<void> {
+    (await this.userRepository.delete(id)) as DeleteResult;
   }
 
   async validateCredentials(

--- a/backend/src/domain/repositories/user.repository.interface.ts
+++ b/backend/src/domain/repositories/user.repository.interface.ts
@@ -5,8 +5,10 @@ export const USER_REPOSITORY = 'USER_REPOSITORY';
 export interface IUserRepository {
   findById(id: string): Promise<User | null>;
   findByEmail(email: string): Promise<User | null>;
+  findBySchoolId(schoolId: string): Promise<User[]>;
   create(
     data: Omit<User, 'id' | 'createdAt'> & { passwordHash: string },
   ): Promise<User>;
+  delete(id: string): Promise<void>;
   validateCredentials(email: string, password: string): Promise<User | null>;
 }

--- a/backend/src/domain/use-cases/create-school-admin.use-case.spec.ts
+++ b/backend/src/domain/use-cases/create-school-admin.use-case.spec.ts
@@ -1,0 +1,120 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { CreateSchoolAdminUseCase } from './create-school-admin.use-case';
+import { IUserRepository } from '../repositories/user.repository.interface';
+import { ISchoolRepository } from '../repositories/school.repository.interface';
+import { User } from '../entities/user.entity';
+import { School } from '../entities/school.entity';
+
+jest.mock('bcrypt');
+
+describe('CreateSchoolAdminUseCase', () => {
+  let useCase: CreateSchoolAdminUseCase;
+  let userRepositoryMock: jest.Mocked<IUserRepository>;
+  let schoolRepositoryMock: jest.Mocked<ISchoolRepository>;
+
+  const mockSchool: School = {
+    id: 'school-123',
+    name: 'Test School',
+    lat: -23.5505,
+    lng: -46.6333,
+    geofenceRadiusMeters: 500,
+    notificationThresholdMeters: 1000,
+    inviteCode: 'AB3X7Y2Z',
+    createdAt: new Date(),
+  };
+
+  const mockUser: User = {
+    id: 'user-456',
+    name: 'Jane Doe',
+    email: 'jane@school.com',
+    role: 'school_admin',
+    schoolId: 'school-123',
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    userRepositoryMock = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findBySchoolId: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      validateCredentials: jest.fn(),
+    } as jest.Mocked<IUserRepository>;
+
+    schoolRepositoryMock = {
+      findById: jest.fn(),
+      create: jest.fn(),
+      findAll: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findParentsWithinGeofence: jest.fn(),
+    } as any;
+
+    useCase = new CreateSchoolAdminUseCase(
+      userRepositoryMock,
+      schoolRepositoryMock,
+    );
+  });
+
+  it('should create a school_admin user successfully', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    userRepositoryMock.findByEmail.mockResolvedValue(null);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+    userRepositoryMock.create.mockResolvedValue(mockUser);
+
+    const result = await useCase.execute({
+      name: 'Jane Doe',
+      email: 'jane@school.com',
+      password: 'SecurePass123',
+      schoolId: 'school-123',
+    });
+
+    expect(result).toEqual(mockUser);
+    expect(schoolRepositoryMock.findById).toHaveBeenCalledWith('school-123');
+    expect(userRepositoryMock.findByEmail).toHaveBeenCalledWith(
+      'jane@school.com',
+    );
+    expect(bcrypt.hash).toHaveBeenCalledWith('SecurePass123', 10);
+    expect(userRepositoryMock.create).toHaveBeenCalledWith({
+      name: 'Jane Doe',
+      email: 'jane@school.com',
+      role: 'school_admin',
+      schoolId: 'school-123',
+      passwordHash: 'hashed-password',
+    });
+  });
+
+  it('should throw NotFoundException when school does not exist', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute({
+        name: 'Jane Doe',
+        email: 'jane@school.com',
+        password: 'SecurePass123',
+        schoolId: 'non-existent-school',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(userRepositoryMock.findByEmail).not.toHaveBeenCalled();
+    expect(userRepositoryMock.create).not.toHaveBeenCalled();
+  });
+
+  it('should throw ConflictException when email already exists', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    userRepositoryMock.findByEmail.mockResolvedValue(mockUser);
+
+    await expect(
+      useCase.execute({
+        name: 'Jane Doe',
+        email: 'jane@school.com',
+        password: 'SecurePass123',
+        schoolId: 'school-123',
+      }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(userRepositoryMock.create).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domain/use-cases/create-school-admin.use-case.ts
+++ b/backend/src/domain/use-cases/create-school-admin.use-case.ts
@@ -1,0 +1,52 @@
+import { Injectable, Inject, ConflictException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../repositories/user.repository.interface';
+import {
+  ISchoolRepository,
+  SCHOOL_REPOSITORY,
+} from '../repositories/school.repository.interface';
+import { User } from '../entities/user.entity';
+import { NotFoundException } from '@nestjs/common';
+
+export interface CreateSchoolAdminInput {
+  name: string;
+  email: string;
+  password: string;
+  schoolId: string;
+}
+
+@Injectable()
+export class CreateSchoolAdminUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository,
+    @Inject(SCHOOL_REPOSITORY)
+    private readonly schoolRepository: ISchoolRepository,
+  ) {}
+
+  async execute(input: CreateSchoolAdminInput): Promise<User> {
+    const school = await this.schoolRepository.findById(input.schoolId);
+    if (!school) {
+      throw new NotFoundException(`School with ID ${input.schoolId} not found`);
+    }
+
+    const existing = await this.userRepository.findByEmail(input.email);
+    if (existing) {
+      throw new ConflictException(
+        `User with email ${input.email} already exists`,
+      );
+    }
+
+    const passwordHash = await bcrypt.hash(input.password, 10);
+
+    return this.userRepository.create({
+      name: input.name,
+      email: input.email,
+      role: 'school_admin',
+      schoolId: input.schoolId,
+      passwordHash,
+    });
+  }
+}

--- a/backend/src/domain/use-cases/delete-admin-user.use-case.spec.ts
+++ b/backend/src/domain/use-cases/delete-admin-user.use-case.spec.ts
@@ -1,0 +1,51 @@
+import { NotFoundException } from '@nestjs/common';
+import { DeleteAdminUserUseCase } from './delete-admin-user.use-case';
+import { IUserRepository } from '../repositories/user.repository.interface';
+import { User } from '../entities/user.entity';
+
+describe('DeleteAdminUserUseCase', () => {
+  let useCase: DeleteAdminUserUseCase;
+  let userRepositoryMock: jest.Mocked<IUserRepository>;
+
+  const mockUser: User = {
+    id: 'user-456',
+    name: 'Jane Doe',
+    email: 'jane@school.com',
+    role: 'school_admin',
+    schoolId: 'school-123',
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    userRepositoryMock = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findBySchoolId: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      validateCredentials: jest.fn(),
+    } as jest.Mocked<IUserRepository>;
+
+    useCase = new DeleteAdminUserUseCase(userRepositoryMock);
+  });
+
+  it('should delete user successfully', async () => {
+    userRepositoryMock.findById.mockResolvedValue(mockUser);
+    userRepositoryMock.delete.mockResolvedValue(undefined);
+
+    await useCase.execute('user-456');
+
+    expect(userRepositoryMock.findById).toHaveBeenCalledWith('user-456');
+    expect(userRepositoryMock.delete).toHaveBeenCalledWith('user-456');
+  });
+
+  it('should throw NotFoundException when user does not exist', async () => {
+    userRepositoryMock.findById.mockResolvedValue(null);
+
+    await expect(useCase.execute('non-existent-user')).rejects.toThrow(
+      NotFoundException,
+    );
+
+    expect(userRepositoryMock.delete).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domain/use-cases/delete-admin-user.use-case.ts
+++ b/backend/src/domain/use-cases/delete-admin-user.use-case.ts
@@ -1,0 +1,21 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../repositories/user.repository.interface';
+
+@Injectable()
+export class DeleteAdminUserUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository,
+  ) {}
+
+  async execute(userId: string): Promise<void> {
+    const user = await this.userRepository.findById(userId);
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    await this.userRepository.delete(userId);
+  }
+}

--- a/backend/src/domain/use-cases/list-school-admins.use-case.spec.ts
+++ b/backend/src/domain/use-cases/list-school-admins.use-case.spec.ts
@@ -1,0 +1,99 @@
+import { NotFoundException } from '@nestjs/common';
+import { ListSchoolAdminsUseCase } from './list-school-admins.use-case';
+import { IUserRepository } from '../repositories/user.repository.interface';
+import { ISchoolRepository } from '../repositories/school.repository.interface';
+import { User } from '../entities/user.entity';
+import { School } from '../entities/school.entity';
+
+describe('ListSchoolAdminsUseCase', () => {
+  let useCase: ListSchoolAdminsUseCase;
+  let userRepositoryMock: jest.Mocked<IUserRepository>;
+  let schoolRepositoryMock: jest.Mocked<ISchoolRepository>;
+
+  const mockSchool: School = {
+    id: 'school-123',
+    name: 'Test School',
+    lat: -23.5505,
+    lng: -46.6333,
+    geofenceRadiusMeters: 500,
+    notificationThresholdMeters: 1000,
+    inviteCode: 'AB3X7Y2Z',
+    createdAt: new Date(),
+  };
+
+  const mockAdmins: User[] = [
+    {
+      id: 'user-1',
+      name: 'Admin One',
+      email: 'admin1@school.com',
+      role: 'school_admin',
+      schoolId: 'school-123',
+      createdAt: new Date(),
+    },
+    {
+      id: 'user-2',
+      name: 'Admin Two',
+      email: 'admin2@school.com',
+      role: 'school_admin',
+      schoolId: 'school-123',
+      createdAt: new Date(),
+    },
+  ];
+
+  beforeEach(() => {
+    userRepositoryMock = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findBySchoolId: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      validateCredentials: jest.fn(),
+    } as jest.Mocked<IUserRepository>;
+
+    schoolRepositoryMock = {
+      findById: jest.fn(),
+      create: jest.fn(),
+      findAll: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findParentsWithinGeofence: jest.fn(),
+    } as any;
+
+    useCase = new ListSchoolAdminsUseCase(
+      userRepositoryMock,
+      schoolRepositoryMock,
+    );
+  });
+
+  it('should return admins for a valid school', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    userRepositoryMock.findBySchoolId.mockResolvedValue(mockAdmins);
+
+    const result = await useCase.execute('school-123');
+
+    expect(result.admins).toEqual(mockAdmins);
+    expect(schoolRepositoryMock.findById).toHaveBeenCalledWith('school-123');
+    expect(userRepositoryMock.findBySchoolId).toHaveBeenCalledWith(
+      'school-123',
+    );
+  });
+
+  it('should return empty array when school has no admins', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    userRepositoryMock.findBySchoolId.mockResolvedValue([]);
+
+    const result = await useCase.execute('school-123');
+
+    expect(result.admins).toEqual([]);
+  });
+
+  it('should throw NotFoundException when school does not exist', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(null);
+
+    await expect(useCase.execute('non-existent-school')).rejects.toThrow(
+      NotFoundException,
+    );
+
+    expect(userRepositoryMock.findBySchoolId).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domain/use-cases/list-school-admins.use-case.ts
+++ b/backend/src/domain/use-cases/list-school-admins.use-case.ts
@@ -1,0 +1,29 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import {
+  IUserRepository,
+  USER_REPOSITORY,
+} from '../repositories/user.repository.interface';
+import {
+  ISchoolRepository,
+  SCHOOL_REPOSITORY,
+} from '../repositories/school.repository.interface';
+import { User } from '../entities/user.entity';
+
+@Injectable()
+export class ListSchoolAdminsUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository,
+    @Inject(SCHOOL_REPOSITORY)
+    private readonly schoolRepository: ISchoolRepository,
+  ) {}
+
+  async execute(schoolId: string): Promise<{ admins: User[] }> {
+    const school = await this.schoolRepository.findById(schoolId);
+    if (!school) {
+      throw new NotFoundException(`School with ID ${schoolId} not found`);
+    }
+
+    const admins = await this.userRepository.findBySchoolId(schoolId);
+    return { admins };
+  }
+}

--- a/backend/src/infrastructure/auth/admin-jwt.strategy.spec.ts
+++ b/backend/src/infrastructure/auth/admin-jwt.strategy.spec.ts
@@ -26,7 +26,9 @@ describe('AdminJwtStrategy', () => {
     userRepositoryMock = {
       findById: jest.fn(),
       findByEmail: jest.fn(),
+      findBySchoolId: jest.fn(),
       create: jest.fn(),
+      delete: jest.fn(),
       validateCredentials: jest.fn(),
     } as jest.Mocked<IUserRepository>;
 

--- a/backend/src/presentation/admin/admin-schools.controller.spec.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.spec.ts
@@ -6,6 +6,7 @@ import { GetSchoolUseCase } from '../../domain/use-cases/get-school.use-case';
 import { GetSchoolInviteUseCase } from '../../domain/use-cases/get-school-invite.use-case';
 import { RegenerateSchoolInviteUseCase } from '../../domain/use-cases/regenerate-school-invite.use-case';
 import { ListSchoolParentsUseCase } from '../../domain/use-cases/list-school-parents.use-case';
+import { ListSchoolAdminsUseCase } from '../../domain/use-cases/list-school-admins.use-case';
 import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
 import { GetSchoolStatsUseCase } from '../../domain/use-cases/get-school-stats.use-case';
 import { UpdateSchoolConfigUseCase } from '../../domain/use-cases/update-school-config.use-case';
@@ -74,6 +75,9 @@ describe('AdminSchoolsController', () => {
     const mockListSchoolParentsUseCase = {
       execute: jest.fn(),
     };
+    const mockListSchoolAdminsUseCase = {
+      execute: jest.fn(),
+    };
     const mockGetSchoolArrivalsUseCase = {
       execute: jest.fn(),
     };
@@ -101,6 +105,10 @@ describe('AdminSchoolsController', () => {
         {
           provide: ListSchoolParentsUseCase,
           useValue: mockListSchoolParentsUseCase,
+        },
+        {
+          provide: ListSchoolAdminsUseCase,
+          useValue: mockListSchoolAdminsUseCase,
         },
         {
           provide: GetSchoolArrivalsUseCase,

--- a/backend/src/presentation/admin/admin-schools.controller.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.ts
@@ -23,6 +23,7 @@ import { GetSchoolUseCase } from '../../domain/use-cases/get-school.use-case';
 import { GetSchoolInviteUseCase } from '../../domain/use-cases/get-school-invite.use-case';
 import { RegenerateSchoolInviteUseCase } from '../../domain/use-cases/regenerate-school-invite.use-case';
 import { ListSchoolParentsUseCase } from '../../domain/use-cases/list-school-parents.use-case';
+import { ListSchoolAdminsUseCase } from '../../domain/use-cases/list-school-admins.use-case';
 import {
   GetSchoolArrivalsUseCase,
   GetSchoolArrivalsInput,
@@ -58,6 +59,7 @@ export class AdminSchoolsController {
     private readonly getSchoolInviteUseCase: GetSchoolInviteUseCase,
     private readonly regenerateSchoolInviteUseCase: RegenerateSchoolInviteUseCase,
     private readonly listSchoolParentsUseCase: ListSchoolParentsUseCase,
+    private readonly listSchoolAdminsUseCase: ListSchoolAdminsUseCase,
     private readonly getSchoolArrivalsUseCase: GetSchoolArrivalsUseCase,
     private readonly getSchoolStatsUseCase: GetSchoolStatsUseCase,
     private readonly updateSchoolConfigUseCase: UpdateSchoolConfigUseCase,
@@ -125,6 +127,28 @@ export class AdminSchoolsController {
       geofenceRadiusMeters: school.geofenceRadiusMeters,
       notificationThresholdMeters: school.notificationThresholdMeters,
     };
+  }
+
+  @Get(':schoolId/admins')
+  @Roles('super_admin')
+  async listAdmins(@Param('schoolId') schoolId: string): Promise<
+    {
+      id: string;
+      name: string;
+      email: string;
+      schoolId: string | null;
+      createdAt: Date;
+    }[]
+  > {
+    const result = await this.listSchoolAdminsUseCase.execute(schoolId);
+
+    return result.admins.map((admin) => ({
+      id: admin.id,
+      name: admin.name,
+      email: admin.email,
+      schoolId: admin.schoolId,
+      createdAt: admin.createdAt,
+    }));
   }
 
   @Get(':schoolId/arrivals')

--- a/backend/src/presentation/admin/admin-users.controller.ts
+++ b/backend/src/presentation/admin/admin-users.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Controller,
+  Post,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { AdminJwtAuthGuard } from '../../infrastructure/auth/admin-jwt-auth.guard';
+import { RolesGuard } from '../../infrastructure/auth/roles.guard';
+import { Roles } from '../../infrastructure/auth/roles.decorator';
+import { CreateSchoolAdminUseCase } from '../../domain/use-cases/create-school-admin.use-case';
+import { ListSchoolAdminsUseCase } from '../../domain/use-cases/list-school-admins.use-case';
+import { DeleteAdminUserUseCase } from '../../domain/use-cases/delete-admin-user.use-case';
+import { CreateSchoolAdminDto } from './dtos/create-school-admin.dto';
+
+interface AdminUserResponseDto {
+  id: string;
+  name: string;
+  email: string;
+  schoolId: string | null;
+  createdAt: Date;
+}
+
+@ApiTags('admin/users')
+@Controller('admin/users')
+@UseGuards(AdminJwtAuthGuard, RolesGuard)
+@ApiBearerAuth('admin-jwt')
+export class AdminUsersController {
+  constructor(
+    private readonly createSchoolAdminUseCase: CreateSchoolAdminUseCase,
+    private readonly listSchoolAdminsUseCase: ListSchoolAdminsUseCase,
+    private readonly deleteAdminUserUseCase: DeleteAdminUserUseCase,
+  ) {}
+
+  @Post()
+  @Roles('super_admin')
+  @HttpCode(HttpStatus.CREATED)
+  async createSchoolAdmin(
+    @Body() dto: CreateSchoolAdminDto,
+  ): Promise<AdminUserResponseDto> {
+    const user = await this.createSchoolAdminUseCase.execute({
+      name: dto.name,
+      email: dto.email,
+      password: dto.password,
+      schoolId: dto.schoolId,
+    });
+
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      schoolId: user.schoolId,
+      createdAt: user.createdAt,
+    };
+  }
+
+  @Delete(':userId')
+  @Roles('super_admin')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteAdminUser(@Param('userId') userId: string): Promise<void> {
+    await this.deleteAdminUserUseCase.execute(userId);
+  }
+}

--- a/backend/src/presentation/admin/admin.module.ts
+++ b/backend/src/presentation/admin/admin.module.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { DataModule } from '@data/data.module';
 import { AdminAuthController } from './admin-auth.controller';
 import { AdminSchoolsController } from './admin-schools.controller';
+import { AdminUsersController } from './admin-users.controller';
 import { AdminAuthService } from './admin-auth.service';
 import { AdminJwtStrategy } from '@infrastructure/auth/admin-jwt.strategy';
 import { parseJwtExpiresIn } from '@infrastructure/auth/jwt.constants';
@@ -14,6 +15,9 @@ import { GetSchoolUseCase } from '@domain/use-cases/get-school.use-case';
 import { GetSchoolInviteUseCase } from '@domain/use-cases/get-school-invite.use-case';
 import { RegenerateSchoolInviteUseCase } from '@domain/use-cases/regenerate-school-invite.use-case';
 import { ListSchoolParentsUseCase } from '@domain/use-cases/list-school-parents.use-case';
+import { CreateSchoolAdminUseCase } from '@domain/use-cases/create-school-admin.use-case';
+import { ListSchoolAdminsUseCase } from '@domain/use-cases/list-school-admins.use-case';
+import { DeleteAdminUserUseCase } from '@domain/use-cases/delete-admin-user.use-case';
 import { GetSchoolArrivalsUseCase } from '@domain/use-cases/get-school-arrivals.use-case';
 import { GetSchoolStatsUseCase } from '@domain/use-cases/get-school-stats.use-case';
 import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-config.use-case';
@@ -34,7 +38,11 @@ import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-confi
       }),
     }),
   ],
-  controllers: [AdminAuthController, AdminSchoolsController],
+  controllers: [
+    AdminAuthController,
+    AdminSchoolsController,
+    AdminUsersController,
+  ],
   providers: [
     AdminAuthService,
     AdminJwtStrategy,
@@ -44,6 +52,9 @@ import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-confi
     GetSchoolInviteUseCase,
     RegenerateSchoolInviteUseCase,
     ListSchoolParentsUseCase,
+    ListSchoolAdminsUseCase,
+    CreateSchoolAdminUseCase,
+    DeleteAdminUserUseCase,
     GetSchoolArrivalsUseCase,
     GetSchoolStatsUseCase,
     UpdateSchoolConfigUseCase,

--- a/backend/src/presentation/admin/dtos/create-school-admin.dto.ts
+++ b/backend/src/presentation/admin/dtos/create-school-admin.dto.ts
@@ -1,0 +1,36 @@
+import { IsEmail, IsString, IsUUID, MinLength, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateSchoolAdminDto {
+  @ApiProperty({ example: 'Jane Doe', description: 'Admin full name' })
+  @IsString()
+  @MinLength(2, { message: 'Name must be at least 2 characters long' })
+  name: string;
+
+  @ApiProperty({
+    example: 'jane@school.com',
+    description: 'Admin email address (must be unique)',
+  })
+  @IsEmail({}, { message: 'Please provide a valid email address' })
+  email: string;
+
+  @ApiProperty({
+    example: 'SecurePass123',
+    description:
+      'Password (min 8 chars, must contain uppercase, lowercase, and number)',
+  })
+  @IsString()
+  @MinLength(8, { message: 'Password must be at least 8 characters long' })
+  @Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, {
+    message:
+      'Password must contain at least one uppercase letter, one lowercase letter, and one number',
+  })
+  password: string;
+
+  @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    description: 'School UUID the admin belongs to',
+  })
+  @IsUUID('4', { message: 'schoolId must be a valid UUID' })
+  schoolId: string;
+}


### PR DESCRIPTION
## Summary

- `POST /admin/users` — create a `school_admin` user (super_admin only)
- `GET /admin/schools/:schoolId/admins` — list admins for a school (super_admin only)
- `DELETE /admin/users/:userId` — delete an admin user (super_admin only)
- Extends `IUserRepository` with `findBySchoolId` and `delete`
- `CreateSchoolAdminDto` with full class-validator/Swagger decorators

## Test plan

- [x] `POST /admin/users` with valid data → 201 with user object (no password)
- [x] `POST /admin/users` with non-existent schoolId → 404
- [x] `POST /admin/users` with duplicate email → 409
- [x] `POST /admin/users` as `school_admin` → 403
- [x] `GET /admin/schools/:schoolId/admins` → 200 with array
- [x] `GET /admin/schools/:schoolId/admins` with non-existent school → 404
- [x] `GET /admin/schools/:schoolId/admins` as `school_admin` → 403
- [x] `DELETE /admin/users/:userId` → 204
- [x] `DELETE /admin/users/:userId` with non-existent id → 404
- [x] `DELETE /admin/users/:userId` as `school_admin` → 403

Closes #241