### PR TITLE
feat: admin user management pages + remove parent from school

### DIFF
--- a/backend/src/domain/use-cases/remove-school-parent.use-case.spec.ts
+++ b/backend/src/domain/use-cases/remove-school-parent.use-case.spec.ts
@@ -1,0 +1,107 @@
+import { NotFoundException } from '@nestjs/common';
+import { RemoveSchoolParentUseCase } from './remove-school-parent.use-case';
+import { IParentRepository } from '../repositories/parent.repository.interface';
+import { ISchoolRepository } from '../repositories/school.repository.interface';
+import { School } from '../entities/school.entity';
+import { Parent } from '../entities/parent.entity';
+
+describe('RemoveSchoolParentUseCase', () => {
+  let useCase: RemoveSchoolParentUseCase;
+  let parentRepositoryMock: jest.Mocked<IParentRepository>;
+  let schoolRepositoryMock: jest.Mocked<ISchoolRepository>;
+
+  const mockSchool: School = {
+    id: 'school-123',
+    name: 'Test School',
+    lat: -23.5505,
+    lng: -46.6333,
+    geofenceRadiusMeters: 500,
+    notificationThresholdMeters: 1000,
+    inviteCode: 'AB3X7Y2Z',
+    createdAt: new Date(),
+  };
+
+  const mockParent: Parent = {
+    id: 'parent-456',
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '+5511999999999',
+    schoolId: 'school-123',
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    parentRepositoryMock = {
+      findById: jest.fn(),
+      findByEmail: jest.fn(),
+      findBySchoolId: jest.fn(),
+      findByIds: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      validateCredentials: jest.fn(),
+    } as jest.Mocked<IParentRepository>;
+
+    schoolRepositoryMock = {
+      findById: jest.fn(),
+      create: jest.fn(),
+      findAll: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      findParentsWithinGeofence: jest.fn(),
+    } as any;
+
+    useCase = new RemoveSchoolParentUseCase(
+      parentRepositoryMock,
+      schoolRepositoryMock,
+    );
+  });
+
+  it('should remove parent from school successfully', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    parentRepositoryMock.findById.mockResolvedValue(mockParent);
+    parentRepositoryMock.delete.mockResolvedValue(undefined);
+
+    await useCase.execute('school-123', 'parent-456');
+
+    expect(schoolRepositoryMock.findById).toHaveBeenCalledWith('school-123');
+    expect(parentRepositoryMock.findById).toHaveBeenCalledWith('parent-456');
+    expect(parentRepositoryMock.delete).toHaveBeenCalledWith('parent-456');
+  });
+
+  it('should throw NotFoundException when school does not exist', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute('non-existent-school', 'parent-456'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(parentRepositoryMock.findById).not.toHaveBeenCalled();
+    expect(parentRepositoryMock.delete).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFoundException when parent does not exist', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    parentRepositoryMock.findById.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute('school-123', 'non-existent-parent'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(parentRepositoryMock.delete).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFoundException when parent belongs to a different school', async () => {
+    schoolRepositoryMock.findById.mockResolvedValue(mockSchool);
+    parentRepositoryMock.findById.mockResolvedValue({
+      ...mockParent,
+      schoolId: 'other-school',
+    });
+
+    await expect(
+      useCase.execute('school-123', 'parent-456'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(parentRepositoryMock.delete).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/domain/use-cases/remove-school-parent.use-case.spec.ts
+++ b/backend/src/domain/use-cases/remove-school-parent.use-case.spec.ts
@@ -98,9 +98,9 @@ describe('RemoveSchoolParentUseCase', () => {
       schoolId: 'other-school',
     });
 
-    await expect(
-      useCase.execute('school-123', 'parent-456'),
-    ).rejects.toThrow(NotFoundException);
+    await expect(useCase.execute('school-123', 'parent-456')).rejects.toThrow(
+      NotFoundException,
+    );
 
     expect(parentRepositoryMock.delete).not.toHaveBeenCalled();
   });

--- a/backend/src/domain/use-cases/remove-school-parent.use-case.ts
+++ b/backend/src/domain/use-cases/remove-school-parent.use-case.ts
@@ -1,0 +1,37 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import {
+  IParentRepository,
+  PARENT_REPOSITORY,
+} from '../repositories/parent.repository.interface';
+import {
+  ISchoolRepository,
+  SCHOOL_REPOSITORY,
+} from '../repositories/school.repository.interface';
+
+@Injectable()
+export class RemoveSchoolParentUseCase {
+  constructor(
+    @Inject(PARENT_REPOSITORY)
+    private readonly parentRepository: IParentRepository,
+    @Inject(SCHOOL_REPOSITORY)
+    private readonly schoolRepository: ISchoolRepository,
+  ) {}
+
+  async execute(schoolId: string, parentId: string): Promise<void> {
+    const school = await this.schoolRepository.findById(schoolId);
+    if (!school) {
+      throw new NotFoundException(`School with ID ${schoolId} not found`);
+    }
+
+    const parent = await this.parentRepository.findById(parentId);
+    if (!parent) {
+      throw new NotFoundException(`Parent with ID ${parentId} not found`);
+    }
+
+    if (parent.schoolId !== schoolId) {
+      throw new NotFoundException(`Parent with ID ${parentId} not found`);
+    }
+
+    await this.parentRepository.delete(parentId);
+  }
+}

--- a/backend/src/presentation/admin/admin-schools.controller.spec.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.spec.ts
@@ -7,6 +7,7 @@ import { GetSchoolInviteUseCase } from '../../domain/use-cases/get-school-invite
 import { RegenerateSchoolInviteUseCase } from '../../domain/use-cases/regenerate-school-invite.use-case';
 import { ListSchoolParentsUseCase } from '../../domain/use-cases/list-school-parents.use-case';
 import { ListSchoolAdminsUseCase } from '../../domain/use-cases/list-school-admins.use-case';
+import { RemoveSchoolParentUseCase } from '../../domain/use-cases/remove-school-parent.use-case';
 import { GetSchoolArrivalsUseCase } from '../../domain/use-cases/get-school-arrivals.use-case';
 import { GetSchoolStatsUseCase } from '../../domain/use-cases/get-school-stats.use-case';
 import { UpdateSchoolConfigUseCase } from '../../domain/use-cases/update-school-config.use-case';
@@ -78,6 +79,9 @@ describe('AdminSchoolsController', () => {
     const mockListSchoolAdminsUseCase = {
       execute: jest.fn(),
     };
+    const mockRemoveSchoolParentUseCase = {
+      execute: jest.fn(),
+    };
     const mockGetSchoolArrivalsUseCase = {
       execute: jest.fn(),
     };
@@ -109,6 +113,10 @@ describe('AdminSchoolsController', () => {
         {
           provide: ListSchoolAdminsUseCase,
           useValue: mockListSchoolAdminsUseCase,
+        },
+        {
+          provide: RemoveSchoolParentUseCase,
+          useValue: mockRemoveSchoolParentUseCase,
         },
         {
           provide: GetSchoolArrivalsUseCase,

--- a/backend/src/presentation/admin/admin-schools.controller.ts
+++ b/backend/src/presentation/admin/admin-schools.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Body,
   Param,
   Query,
@@ -24,6 +25,7 @@ import { GetSchoolInviteUseCase } from '../../domain/use-cases/get-school-invite
 import { RegenerateSchoolInviteUseCase } from '../../domain/use-cases/regenerate-school-invite.use-case';
 import { ListSchoolParentsUseCase } from '../../domain/use-cases/list-school-parents.use-case';
 import { ListSchoolAdminsUseCase } from '../../domain/use-cases/list-school-admins.use-case';
+import { RemoveSchoolParentUseCase } from '../../domain/use-cases/remove-school-parent.use-case';
 import {
   GetSchoolArrivalsUseCase,
   GetSchoolArrivalsInput,
@@ -60,6 +62,7 @@ export class AdminSchoolsController {
     private readonly regenerateSchoolInviteUseCase: RegenerateSchoolInviteUseCase,
     private readonly listSchoolParentsUseCase: ListSchoolParentsUseCase,
     private readonly listSchoolAdminsUseCase: ListSchoolAdminsUseCase,
+    private readonly removeSchoolParentUseCase: RemoveSchoolParentUseCase,
     private readonly getSchoolArrivalsUseCase: GetSchoolArrivalsUseCase,
     private readonly getSchoolStatsUseCase: GetSchoolStatsUseCase,
     private readonly updateSchoolConfigUseCase: UpdateSchoolConfigUseCase,
@@ -259,5 +262,16 @@ export class AdminSchoolsController {
       phone: parent.phone,
       createdAt: parent.createdAt,
     }));
+  }
+
+  @Delete(':schoolId/parents/:parentId')
+  @Roles('super_admin', 'school_admin')
+  @UseGuards(SchoolAccessGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeParent(
+    @Param('schoolId') schoolId: string,
+    @Param('parentId') parentId: string,
+  ): Promise<void> {
+    await this.removeSchoolParentUseCase.execute(schoolId, parentId);
   }
 }

--- a/backend/src/presentation/admin/admin.module.ts
+++ b/backend/src/presentation/admin/admin.module.ts
@@ -18,6 +18,7 @@ import { ListSchoolParentsUseCase } from '@domain/use-cases/list-school-parents.
 import { CreateSchoolAdminUseCase } from '@domain/use-cases/create-school-admin.use-case';
 import { ListSchoolAdminsUseCase } from '@domain/use-cases/list-school-admins.use-case';
 import { DeleteAdminUserUseCase } from '@domain/use-cases/delete-admin-user.use-case';
+import { RemoveSchoolParentUseCase } from '@domain/use-cases/remove-school-parent.use-case';
 import { GetSchoolArrivalsUseCase } from '@domain/use-cases/get-school-arrivals.use-case';
 import { GetSchoolStatsUseCase } from '@domain/use-cases/get-school-stats.use-case';
 import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-config.use-case';
@@ -55,6 +56,7 @@ import { UpdateSchoolConfigUseCase } from '@domain/use-cases/update-school-confi
     ListSchoolAdminsUseCase,
     CreateSchoolAdminUseCase,
     DeleteAdminUserUseCase,
+    RemoveSchoolParentUseCase,
     GetSchoolArrivalsUseCase,
     GetSchoolStatsUseCase,
     UpdateSchoolConfigUseCase,

--- a/web/src/app/actions/create-school-admin.action.ts
+++ b/web/src/app/actions/create-school-admin.action.ts
@@ -1,0 +1,31 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { TOKEN_KEY } from '@/lib/auth';
+import { createSchoolAdmin } from '@/lib/server-api';
+import { SchoolAdmin } from '@/types';
+
+export async function createSchoolAdminAction(data: {
+  name: string;
+  email: string;
+  password: string;
+  schoolId: string;
+}): Promise<{ success: boolean; admin?: SchoolAdmin; error?: string }> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get(TOKEN_KEY)?.value;
+
+    if (!token) {
+      return { success: false, error: 'Não autenticado' };
+    }
+
+    const admin = await createSchoolAdmin(data, token);
+    return { success: true, admin };
+  } catch (error) {
+    console.error('Error creating school admin:', error);
+    return {
+      success: false,
+      error: 'Erro ao criar administrador. Verifique os dados e tente novamente.',
+    };
+  }
+}

--- a/web/src/app/actions/delete-admin-user.action.ts
+++ b/web/src/app/actions/delete-admin-user.action.ts
@@ -1,0 +1,27 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { TOKEN_KEY } from '@/lib/auth';
+import { deleteAdminUser } from '@/lib/server-api';
+
+export async function deleteAdminUserAction(
+  userId: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get(TOKEN_KEY)?.value;
+
+    if (!token) {
+      return { success: false, error: 'Não autenticado' };
+    }
+
+    await deleteAdminUser(userId, token);
+    return { success: true };
+  } catch (error) {
+    console.error('Error deleting admin user:', error);
+    return {
+      success: false,
+      error: 'Erro ao remover administrador. Tente novamente.',
+    };
+  }
+}

--- a/web/src/app/actions/remove-parent.action.ts
+++ b/web/src/app/actions/remove-parent.action.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { TOKEN_KEY } from '@/lib/auth';
+import { removeSchoolParent } from '@/lib/server-api';
+
+export async function removeParentAction(
+  schoolId: string,
+  parentId: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get(TOKEN_KEY)?.value;
+
+    if (!token) {
+      return { success: false, error: 'Não autenticado' };
+    }
+
+    await removeSchoolParent(schoolId, parentId, token);
+    return { success: true };
+  } catch (error) {
+    console.error('Error removing parent:', error);
+    return { success: false, error: 'Erro ao remover pai. Tente novamente.' };
+  }
+}

--- a/web/src/app/dashboard/[schoolId]/admins/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/admins/page.tsx
@@ -1,0 +1,28 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { TOKEN_KEY } from '@/lib/auth';
+import { getSchoolAdmins } from '@/lib/server-api';
+import { AdminsManager } from '@/components/admins/AdminsManager';
+
+interface AdminsPageProps {
+  params: Promise<{ schoolId: string }>;
+}
+
+export default async function AdminsPage({ params }: AdminsPageProps) {
+  const { schoolId } = await params;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(TOKEN_KEY)?.value;
+
+  if (!token) {
+    redirect('/login');
+  }
+
+  const admins = await getSchoolAdmins(schoolId, token).catch(() => []);
+
+  return (
+    <div className="p-8">
+      <AdminsManager schoolId={schoolId} initialAdmins={admins} />
+    </div>
+  );
+}

--- a/web/src/app/dashboard/[schoolId]/parents/page.tsx
+++ b/web/src/app/dashboard/[schoolId]/parents/page.tsx
@@ -2,17 +2,10 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { TOKEN_KEY } from '@/lib/auth';
 import { getSchoolParents } from '@/lib/server-api';
+import { ParentsTable } from '@/components/parents/ParentsTable';
 
 interface ParentsPageProps {
   params: Promise<{ schoolId: string }>;
-}
-
-function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('pt-BR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  });
 }
 
 export default async function ParentsPage({ params }: ParentsPageProps) {
@@ -32,50 +25,13 @@ export default async function ParentsPage({ params }: ParentsPageProps) {
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900">Pais Cadastrados</h1>
         <p className="text-gray-600 mt-2">
-          {parents.length} {parents.length === 1 ? 'pai cadastrado' : 'pais cadastrados'} nesta
+          {parents.length}{' '}
+          {parents.length === 1 ? 'pai cadastrado' : 'pais cadastrados'} nesta
           escola
         </p>
       </div>
 
-      {parents.length === 0 ? (
-        <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
-          <p className="text-gray-400 text-lg">Nenhum pai cadastrado ainda.</p>
-          <p className="text-gray-400 text-sm mt-1">
-            Compartilhe o código de convite para que pais possam se registrar.
-          </p>
-        </div>
-      ) : (
-        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-gray-200 bg-gray-50">
-                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Nome
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Email
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Telefone
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                  Cadastrado em
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {parents.map((parent) => (
-                <tr key={parent.id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-6 py-4 text-sm font-medium text-gray-900">{parent.name}</td>
-                  <td className="px-6 py-4 text-sm text-gray-600">{parent.email}</td>
-                  <td className="px-6 py-4 text-sm text-gray-600">{parent.phone}</td>
-                  <td className="px-6 py-4 text-sm text-gray-500">{formatDate(parent.createdAt)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+      <ParentsTable schoolId={schoolId} initialParents={parents} />
     </div>
   );
 }

--- a/web/src/components/admins/AdminsManager.tsx
+++ b/web/src/components/admins/AdminsManager.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState } from 'react';
+import { SchoolAdmin } from '@/types';
+import { createSchoolAdminAction } from '@/app/actions/create-school-admin.action';
+import { deleteAdminUserAction } from '@/app/actions/delete-admin-user.action';
+
+interface AdminsManagerProps {
+  schoolId: string;
+  initialAdmins: SchoolAdmin[];
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+export function AdminsManager({ schoolId, initialAdmins }: AdminsManagerProps) {
+  const [admins, setAdmins] = useState<SchoolAdmin[]>(initialAdmins);
+  const [showForm, setShowForm] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    name: '',
+    email: '',
+    password: '',
+  });
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsCreating(true);
+    setFormError(null);
+
+    const result = await createSchoolAdminAction({
+      ...form,
+      schoolId,
+    });
+
+    if (result.success && result.admin) {
+      setAdmins((prev) => [...prev, result.admin!]);
+      setForm({ name: '', email: '', password: '' });
+      setShowForm(false);
+    } else {
+      setFormError(result.error ?? 'Erro desconhecido');
+    }
+
+    setIsCreating(false);
+  };
+
+  const handleDelete = async (userId: string) => {
+    setDeletingId(userId);
+    setDeleteError(null);
+
+    const result = await deleteAdminUserAction(userId);
+
+    if (result.success) {
+      setAdmins((prev) => prev.filter((a) => a.id !== userId));
+    } else {
+      setDeleteError(result.error ?? 'Erro desconhecido');
+    }
+
+    setDeletingId(null);
+    setConfirmDeleteId(null);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Administradores</h1>
+          <p className="text-gray-600 mt-1">
+            {admins.length}{' '}
+            {admins.length === 1 ? 'administrador' : 'administradores'} nesta
+            escola
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            setShowForm((v) => !v);
+            setFormError(null);
+          }}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm"
+        >
+          {showForm ? 'Cancelar' : '+ Novo administrador'}
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="bg-white rounded-xl border border-gray-200 p-6 mb-6 max-w-lg">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+            Novo administrador
+          </h2>
+          <form onSubmit={handleCreate} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Nome
+              </label>
+              <input
+                type="text"
+                required
+                minLength={2}
+                value={form.name}
+                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Nome completo"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Email
+              </label>
+              <input
+                type="email"
+                required
+                value={form.email}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, email: e.target.value }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="email@escola.com"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Senha
+              </label>
+              <input
+                type="password"
+                required
+                minLength={8}
+                value={form.password}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, password: e.target.value }))
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Mínimo 8 caracteres"
+              />
+            </div>
+
+            {formError && (
+              <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+                {formError}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={isCreating}
+              className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isCreating ? 'Criando...' : 'Criar administrador'}
+            </button>
+          </form>
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {deleteError}
+        </div>
+      )}
+
+      {admins.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
+          <p className="text-gray-400 text-lg">
+            Nenhum administrador cadastrado ainda.
+          </p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-gray-200 bg-gray-50">
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Nome
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Email
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                  Cadastrado em
+                </th>
+                <th className="px-6 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {admins.map((admin) => (
+                <tr key={admin.id} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                    {admin.name}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-600">
+                    {admin.email}
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    {formatDate(admin.createdAt)}
+                  </td>
+                  <td className="px-6 py-4 text-right">
+                    {confirmDeleteId === admin.id ? (
+                      <div className="flex items-center justify-end gap-2">
+                        <span className="text-xs text-gray-600">Confirmar?</span>
+                        <button
+                          onClick={() => handleDelete(admin.id)}
+                          disabled={deletingId === admin.id}
+                          className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700 disabled:opacity-50"
+                        >
+                          {deletingId === admin.id ? '...' : 'Sim'}
+                        </button>
+                        <button
+                          onClick={() => setConfirmDeleteId(null)}
+                          className="px-3 py-1 bg-gray-200 text-gray-700 rounded text-xs hover:bg-gray-300"
+                        >
+                          Não
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmDeleteId(admin.id)}
+                        className="px-3 py-1 text-red-600 border border-red-200 rounded text-xs hover:bg-red-50 transition-colors"
+                      >
+                        Remover
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/layout/DashboardSidebar.tsx
+++ b/web/src/components/layout/DashboardSidebar.tsx
@@ -27,6 +27,11 @@ export function DashboardSidebar({
       icon: '👥',
     },
     {
+      href: `/dashboard/${schoolId}/admins`,
+      label: 'Administradores',
+      icon: '👤',
+    },
+    {
       href: `/dashboard/${schoolId}/invite`,
       label: 'Código de Convite',
       icon: '🔑',

--- a/web/src/components/parents/ParentsTable.tsx
+++ b/web/src/components/parents/ParentsTable.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import { SchoolParent } from '@/types';
+import { removeParentAction } from '@/app/actions/remove-parent.action';
+
+interface ParentsTableProps {
+  schoolId: string;
+  initialParents: SchoolParent[];
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+export function ParentsTable({ schoolId, initialParents }: ParentsTableProps) {
+  const [parents, setParents] = useState<SchoolParent[]>(initialParents);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async (parentId: string) => {
+    setDeletingId(parentId);
+    setError(null);
+
+    const result = await removeParentAction(schoolId, parentId);
+
+    if (result.success) {
+      setParents((prev) => prev.filter((p) => p.id !== parentId));
+    } else {
+      setError(result.error ?? 'Erro desconhecido');
+    }
+
+    setDeletingId(null);
+    setConfirmDeleteId(null);
+  };
+
+  if (parents.length === 0) {
+    return (
+      <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
+        <p className="text-gray-400 text-lg">Nenhum pai cadastrado ainda.</p>
+        <p className="text-gray-400 text-sm mt-1">
+          Compartilhe o código de convite para que pais possam se registrar.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {error}
+        </div>
+      )}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-gray-200 bg-gray-50">
+              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                Nome
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                Email
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                Telefone
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                Cadastrado em
+              </th>
+              <th className="px-6 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {parents.map((parent) => (
+              <tr
+                key={parent.id}
+                className="hover:bg-gray-50 transition-colors"
+              >
+                <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                  {parent.name}
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-600">
+                  {parent.email}
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-600">
+                  {parent.phone}
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-500">
+                  {formatDate(parent.createdAt)}
+                </td>
+                <td className="px-6 py-4 text-right">
+                  {confirmDeleteId === parent.id ? (
+                    <div className="flex items-center justify-end gap-2">
+                      <span className="text-xs text-gray-600">Confirmar?</span>
+                      <button
+                        onClick={() => handleDelete(parent.id)}
+                        disabled={deletingId === parent.id}
+                        className="px-3 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700 disabled:opacity-50"
+                      >
+                        {deletingId === parent.id ? '...' : 'Sim'}
+                      </button>
+                      <button
+                        onClick={() => setConfirmDeleteId(null)}
+                        className="px-3 py-1 bg-gray-200 text-gray-700 rounded text-xs hover:bg-gray-300"
+                      >
+                        Não
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmDeleteId(parent.id)}
+                      className="px-3 py-1 text-red-600 border border-red-200 rounded text-xs hover:bg-red-50 transition-colors"
+                    >
+                      Remover
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/web/src/lib/server-api.ts
+++ b/web/src/lib/server-api.ts
@@ -1,4 +1,4 @@
-import { Arrival, School, SchoolStats, SchoolConfig, SchoolParent } from '@/types';
+import { Arrival, School, SchoolStats, SchoolConfig, SchoolParent, SchoolAdmin } from '@/types';
 
 export class UnauthorizedError extends Error {
   constructor() {
@@ -112,4 +112,40 @@ export async function getSchoolParents(
   token: string,
 ): Promise<SchoolParent[]> {
   return serverFetch<SchoolParent[]>(`/admin/schools/${schoolId}/parents`, token);
+}
+
+export async function removeSchoolParent(
+  schoolId: string,
+  parentId: string,
+  token: string,
+): Promise<void> {
+  await serverFetch<void>(
+    `/admin/schools/${schoolId}/parents/${parentId}`,
+    token,
+    { method: 'DELETE' },
+  );
+}
+
+export async function getSchoolAdmins(
+  schoolId: string,
+  token: string,
+): Promise<SchoolAdmin[]> {
+  return serverFetch<SchoolAdmin[]>(`/admin/schools/${schoolId}/admins`, token);
+}
+
+export async function createSchoolAdmin(
+  data: { name: string; email: string; password: string; schoolId: string },
+  token: string,
+): Promise<SchoolAdmin> {
+  return serverFetch<SchoolAdmin>('/admin/users', token, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteAdminUser(
+  userId: string,
+  token: string,
+): Promise<void> {
+  await serverFetch<void>(`/admin/users/${userId}`, token, { method: 'DELETE' });
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -51,3 +51,11 @@ export interface SchoolParent {
   phone: string;
   createdAt: string;
 }
+
+export interface SchoolAdmin {
+  id: string;
+  name: string;
+  email: string;
+  schoolId: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

**Backend**
- `DELETE /admin/schools/:schoolId/parents/:parentId` — remove parent from school (school_admin / super_admin)
- `RemoveSchoolParentUseCase`: validates school, parent existence, and school ownership

**Web**
- `/dashboard/[schoolId]/admins` — list, create, and remove school admins with inline form and delete confirmation
- `/dashboard/[schoolId]/parents` — delete action with two-step confirmation added to existing table
- Sidebar: added "Administradores" nav link
- New server actions: `createSchoolAdminAction`, `deleteAdminUserAction`, `removeParentAction`

## Test plan

- [x] `GET /dashboard/[schoolId]/admins` — lists admins for the school
- [x] Create admin via form → appears in table instantly
- [x] Create admin with duplicate email → shows error message
- [x] Remove admin: click "Remover" → confirmation dialog → confirm → row disappears
- [x] Remove admin: click "Remover" → confirmation dialog → cancel → row stays
- [x] `GET /dashboard/[schoolId]/parents` — lists parents with "Remover" button
- [x] Remove parent: confirm → row disappears
- [x] `DELETE /admin/schools/:schoolId/parents/:parentId` with valid IDs → 204
- [x] `DELETE /admin/schools/:schoolId/parents/:parentId` parent from different school → 404
- [x] `DELETE /admin/schools/:schoolId/parents/:parentId` non-existent parent → 404

Closes #242